### PR TITLE
feat: allow construction of generic method requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev="b4925
 tokio = { version = "1.1", features = ["rt", "macros"] }
 
 [features]
+any = []
 legacy = []
 sandbox = []
 adversarial = []

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ and construct a request using the `methods::tx::RpcTransactionStatusRequest` str
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_jsonrpc_primitives::types::transactions::TransactionInfo;
 
-// create a client and connect to a NEAR JSON-RPC server
 let mainnet_client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 
 let tx_status_request = methods::tx::RpcTransactionStatusRequest {
@@ -30,6 +29,51 @@ let tx_status_request = methods::tx::RpcTransactionStatusRequest {
 let tx_status = mainnet_client.call(tx_status_request).await?;
 
 println!("{:?}", tx_status);
+```
+
+For all intents and purposes, the predefined structures in `methods` should suffice, if you find that they
+don't or you crave extra flexibility, well, you can opt in to use the generic constructor `methods::any()` with the `any` feature flag.
+
+In this example, we retrieve only the parts from the genesis config response that we care about.
+
+```toml
+# in Cargo.toml
+near-jsonrpc-client = { ..., features = ["any"] }
+```
+
+```rust
+use serde::Deserialize;
+use serde_json::json;
+
+use near_jsonrpc_client::{methods, JsonRpcClient};
+use near_primitives::serialize::u128_dec_format;
+use near_primitives::types::*;
+
+#[derive(Debug, Deserialize)]
+struct PartialGenesisConfig {
+    protocol_version: ProtocolVersion,
+    chain_id: String,
+    genesis_height: BlockHeight,
+    epoch_length: BlockHeightDelta,
+    #[serde(with = "u128_dec_format")]
+    min_gas_price: Balance,
+    #[serde(with = "u128_dec_format")]
+    max_gas_price: Balance,
+    #[serde(with = "u128_dec_format")]
+    total_supply: Balance,
+    validators: Vec<AccountInfo>,
+}
+
+impl methods::RpcHandlerResult for PartialGenesisConfig {}
+
+let mainnet_client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
+
+let genesis_config_request =
+    methods::any::<PartialGenesisConfig, ()>("EXPERIMENTAL_genesis_config", json!(null));
+
+let partial_genesis = mainnet_client.call(genesis_config_request).await?;
+
+println!("{:#?}", partial_genesis);
 ```
 
 ## Testing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ impl JsonRpcClient {
         method: M,
     ) -> JsonRpcMethodCallResult<M::Result, M::Error> {
         let (method_name, params) = (
-            M::METHOD_NAME,
+            method.method_name(),
             method.params().map_err(|err| {
                 JsonRpcError::TransportError(RpcTransportError::SendError(
                     JsonRpcTransportSendError::PayloadSerializeError(err),

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -39,13 +39,13 @@ where
     }
 }
 
-pub trait RpcHandlerResult: serde::de::DeserializeOwned + chk::ValidRpcMarkerTrait {
+pub trait RpcHandlerResult: serde::de::DeserializeOwned {
     fn parse_result(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         serde_json::from_value(value)
     }
 }
 
-pub trait RpcHandlerError: serde::de::DeserializeOwned + chk::ValidRpcMarkerTrait {
+pub trait RpcHandlerError: serde::de::DeserializeOwned {
     /// parser for the `.data` field in RpcError, not `.error_struct`
     /// this would only ever be used if `.error_struct` can't be deserialized
     fn parse_raw_error(_value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
@@ -84,46 +84,37 @@ macro_rules! legacy {
 }
 
 macro_rules! impl_ {
-    (RpcMethod for $for_type:ty { $($body:tt)+ }) => {
+    ($valid_trait:ident for $for_type:ty { $($body:tt)+ }) => {
         impl chk::ValidRpcMarkerTrait for $for_type {}
-        impl_!(@final RpcMethod for $for_type {
+        impl $valid_trait for $for_type {
             $($body)+
 
             #[inline(always)]
             fn method_name(&self) -> &str {
                 METHOD_NAME
             }
-        });
-    };
-    ($valid_trait:ident for $for_type:ty { $($body:tt)* }) => {
-        impl chk::ValidRpcMarkerTrait for $for_type {}
-        impl_!(@final $valid_trait for $for_type { $($body)* });
-    };
-    (@final $valid_trait:ident for $for_type:ty { $($body:tt)* }) => {
-        impl $valid_trait for $for_type { $($body)* }
+        }
     };
 }
 
 mod shared_structs {
-    use super::{chk, RpcHandlerError, RpcHandlerResult};
-
-    impl chk::ValidRpcMarkerTrait for () {}
+    use super::{RpcHandlerError, RpcHandlerResult};
 
     // broadcast_tx_async, EXPERIMENTAL_genesis_config, adv_*
-    impl_!(@final RpcHandlerError for () {});
+    impl RpcHandlerError for () {}
 
     // adv_*
-    impl_!(@final RpcHandlerResult for () {
+    impl RpcHandlerResult for () {
         fn parse_result(_value: serde_json::Value) -> Result<Self, serde_json::Error> {
             Ok(())
         }
-    });
+    }
 
     // broadcast_tx_commit, tx
-    impl_!(RpcHandlerResult for near_primitives::views::FinalExecutionOutcomeView {});
+    impl RpcHandlerResult for near_primitives::views::FinalExecutionOutcomeView {}
 
     // broadcast_tx_commit, tx, EXPERIMENTAL_check_tx, EXPERIMENTAL_tx_status
-    impl_!(RpcHandlerError for near_jsonrpc_primitives::types::transactions::RpcTransactionError {
+    impl RpcHandlerError for near_jsonrpc_primitives::types::transactions::RpcTransactionError {
         fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
             match serde_json::from_value::<near_jsonrpc_primitives::errors::ServerError>(value) {
                 Ok(near_jsonrpc_primitives::errors::ServerError::TxExecutionError(
@@ -133,19 +124,19 @@ mod shared_structs {
                 _ => None,
             }
         }
-    });
+    }
 
     // health, status
-    impl_!(RpcHandlerError for near_jsonrpc_primitives::types::status::RpcStatusError {});
+    impl RpcHandlerError for near_jsonrpc_primitives::types::status::RpcStatusError {}
 
     // EXPERIMENTAL_changes, EXPERIMENTAL_changes_in_block
-    impl_!(RpcHandlerError for near_jsonrpc_primitives::types::changes::RpcStateChangesError {});
+    impl RpcHandlerError for near_jsonrpc_primitives::types::changes::RpcStateChangesError {}
 
     // EXPERIMENTAL_broadcast_tx_sync, EXPERIMENTAL_check_tx
-    impl_!(RpcHandlerResult for near_jsonrpc_primitives::types::transactions::RpcBroadcastTxSyncResponse {});
+    impl RpcHandlerResult for near_jsonrpc_primitives::types::transactions::RpcBroadcastTxSyncResponse {}
 
     // validators, EXPERIMENTAL_validators_ordered
-    impl_!(RpcHandlerError for near_jsonrpc_primitives::types::validator::RpcValidatorError {});
+    impl RpcHandlerError for near_jsonrpc_primitives::types::validator::RpcValidatorError {}
 }
 
 #[cfg(feature = "any")]
@@ -203,9 +194,9 @@ impl_method! {
         pub use near_primitives::views::BlockView;
         use near_primitives::types::BlockId;
 
-        impl_!(RpcHandlerResult for BlockView {});
+        impl RpcHandlerResult for BlockView {}
 
-        impl_!(RpcHandlerError for RpcBlockError {});
+        impl RpcHandlerError for RpcBlockError {}
 
         impl_!(RpcMethod for RpcBlockRequest {
             type Result = BlockView;
@@ -265,7 +256,7 @@ impl_method! {
             }
         }
 
-        impl_!(RpcHandlerResult for CryptoHash {});
+        impl RpcHandlerResult for CryptoHash {}
 
         impl_!(RpcMethod for RpcBroadcastTxAsyncRequest {
             type Result = CryptoHash;
@@ -315,9 +306,9 @@ impl_method! {
         pub use near_jsonrpc_primitives::types::chunks::{RpcChunkError, RpcChunkRequest};
         pub use near_primitives::views::ChunkView;
 
-        impl_!(RpcHandlerResult for ChunkView {});
+        impl RpcHandlerResult for ChunkView {}
 
-        impl_!(RpcHandlerError for RpcChunkError {});
+        impl RpcHandlerError for RpcChunkError {}
 
         impl_!(RpcMethod for RpcChunkRequest {
             type Result = ChunkView;
@@ -337,9 +328,9 @@ impl_method! {
         };
         pub use near_primitives::views::GasPriceView;
 
-        impl_!(RpcHandlerResult for GasPriceView {});
+        impl RpcHandlerResult for GasPriceView {}
 
-        impl_!(RpcHandlerError for RpcGasPriceError {});
+        impl RpcHandlerError for RpcGasPriceError {}
 
         impl_!(RpcMethod for RpcGasPriceRequest {
             type Result = GasPriceView;
@@ -361,7 +352,7 @@ impl_method! {
         #[derive(Debug)]
         pub struct RpcHealthRequest;
 
-        impl_!(RpcHandlerResult for RpcHealthResponse {});
+        impl RpcHandlerResult for RpcHealthResponse {}
 
         impl_!(RpcMethod for RpcHealthRequest {
             type Result = RpcHealthResponse;
@@ -377,9 +368,9 @@ impl_method! {
             RpcLightClientProofError,
         };
 
-        impl_!(RpcHandlerResult for RpcLightClientExecutionProofResponse {});
+        impl RpcHandlerResult for RpcLightClientExecutionProofResponse {}
 
-        impl_!(RpcHandlerError for RpcLightClientProofError {});
+        impl RpcHandlerError for RpcLightClientProofError {}
 
         impl_!(RpcMethod for RpcLightClientExecutionProofRequest {
             type Result = RpcLightClientExecutionProofResponse;
@@ -400,9 +391,9 @@ impl_method! {
         pub use near_primitives::views::LightClientBlockView;
         pub type RpcLightClientNextBlockResponse = Option<LightClientBlockView>;
 
-        impl_!(RpcHandlerResult for RpcLightClientNextBlockResponse {});
+        impl RpcHandlerResult for RpcLightClientNextBlockResponse {}
 
-        impl_!(RpcHandlerError for RpcLightClientNextBlockError {});
+        impl RpcHandlerError for RpcLightClientNextBlockError {}
 
         impl_!(RpcMethod for RpcLightClientNextBlockRequest {
             type Result = RpcLightClientNextBlockResponse;
@@ -423,9 +414,9 @@ impl_method! {
         #[derive(Debug)]
         pub struct RpcNetworkInfoRequest;
 
-        impl_!(RpcHandlerResult for NetworkInfoResponse {});
+        impl RpcHandlerResult for NetworkInfoResponse {}
 
-        impl_!(RpcHandlerError for RpcNetworkInfoError {});
+        impl RpcHandlerError for RpcNetworkInfoError {}
 
         impl_!(RpcMethod for RpcNetworkInfoRequest {
             type Result = NetworkInfoResponse;
@@ -440,9 +431,9 @@ impl_method! {
             RpcQueryError, RpcQueryRequest, RpcQueryResponse,
         };
 
-        impl_!(RpcHandlerResult for RpcQueryResponse {});
+        impl RpcHandlerResult for RpcQueryResponse {}
 
-        impl_!(RpcHandlerError for RpcQueryError {});
+        impl RpcHandlerError for RpcQueryError {}
 
         impl_!(RpcMethod for RpcQueryRequest {
             type Result = RpcQueryResponse;
@@ -485,7 +476,7 @@ impl_method! {
         #[derive(Debug)]
         pub struct RpcStatusRequest;
 
-        impl_!(RpcHandlerResult for StatusResponse {});
+        impl RpcHandlerResult for StatusResponse {}
 
         impl_!(RpcMethod for RpcStatusRequest {
             type Result = StatusResponse;
@@ -542,7 +533,7 @@ impl_method! {
         };
         pub use near_primitives::views::EpochValidatorInfo;
 
-        impl_!(RpcHandlerResult for EpochValidatorInfo {});
+        impl RpcHandlerResult for EpochValidatorInfo {}
 
         impl_!(RpcMethod for RpcValidatorRequest {
             type Result = EpochValidatorInfo;
@@ -593,7 +584,7 @@ impl_method! {
             RpcStateChangesInBlockResponse,
         };
 
-        impl_!(RpcHandlerResult for RpcStateChangesInBlockResponse {});
+        impl RpcHandlerResult for RpcStateChangesInBlockResponse {}
 
         impl_!(RpcMethod for RpcStateChangesInBlockByTypeRequest {
             type Result = RpcStateChangesInBlockResponse;
@@ -613,7 +604,7 @@ impl_method! {
             RpcStateChangesInBlockByTypeResponse,
         };
 
-        impl_!(RpcHandlerResult for RpcStateChangesInBlockByTypeResponse {});
+        impl RpcHandlerResult for RpcStateChangesInBlockByTypeResponse {}
 
         impl_!(RpcMethod for RpcStateChangesInBlockRequest {
             type Result = RpcStateChangesInBlockByTypeResponse;
@@ -664,7 +655,7 @@ impl_method! {
         #[derive(Debug)]
         pub struct RpcGenesisConfigRequest;
 
-        impl_!(RpcHandlerResult for GenesisConfig {});
+        impl RpcHandlerResult for GenesisConfig {}
 
         impl_!(RpcMethod for RpcGenesisConfigRequest {
             type Result = GenesisConfig;
@@ -680,9 +671,9 @@ impl_method! {
             RpcProtocolConfigError, RpcProtocolConfigRequest,
         };
 
-        impl_!(RpcHandlerResult for ProtocolConfigView {});
+        impl RpcHandlerResult for ProtocolConfigView {}
 
-        impl_!(RpcHandlerError for RpcProtocolConfigError {});
+        impl RpcHandlerError for RpcProtocolConfigError {}
 
         impl_!(RpcMethod for RpcProtocolConfigRequest {
             type Result = ProtocolConfigView;
@@ -702,9 +693,9 @@ impl_method! {
         };
         pub use near_primitives::views::ReceiptView;
 
-        impl_!(RpcHandlerResult for ReceiptView {});
+        impl RpcHandlerResult for ReceiptView {}
 
-        impl_!(RpcHandlerError for RpcReceiptError {});
+        impl RpcHandlerError for RpcReceiptError {}
 
         impl_!(RpcMethod for RpcReceiptRequest {
             type Result = ReceiptView;
@@ -738,7 +729,7 @@ impl_method! {
             }
         }
 
-        impl_!(RpcHandlerResult for FinalExecutionOutcomeWithReceiptView {});
+        impl RpcHandlerResult for FinalExecutionOutcomeWithReceiptView {}
 
         impl_!(RpcMethod for RpcTransactionStatusRequest {
             type Result = FinalExecutionOutcomeWithReceiptView;
@@ -766,7 +757,7 @@ impl_method! {
             RpcValidatorError, RpcValidatorsOrderedRequest, RpcValidatorsOrderedResponse,
         };
 
-        impl_!(RpcHandlerResult for RpcValidatorsOrderedResponse {});
+        impl RpcHandlerResult for RpcValidatorsOrderedResponse {}
 
         impl_!(RpcMethod for RpcValidatorsOrderedRequest {
             type Result = RpcValidatorsOrderedResponse;
@@ -787,9 +778,9 @@ impl_method! {
             RpcSandboxPatchStateResponse,
         };
 
-        impl_!(RpcHandlerResult for RpcSandboxPatchStateResponse {});
+        impl RpcHandlerResult for RpcSandboxPatchStateResponse {}
 
-        impl_!(RpcHandlerError for RpcSandboxPatchStateError {});
+        impl RpcHandlerError for RpcSandboxPatchStateError {}
 
         impl_!(RpcMethod for RpcSandboxPatchStateRequest {
             type Result = RpcSandboxPatchStateResponse;
@@ -893,7 +884,7 @@ impl_method! {
         #[derive(Debug, Deserialize)]
         pub struct RpcAdversarialGetSavedBlocksResponse(pub u64);
 
-        impl_!(RpcHandlerResult for RpcAdversarialGetSavedBlocksResponse {});
+        impl RpcHandlerResult for RpcAdversarialGetSavedBlocksResponse {}
 
         impl_!(RpcMethod for RpcAdversarialGetSavedBlocksRequest {
             type Result = RpcAdversarialGetSavedBlocksResponse;
@@ -913,7 +904,7 @@ impl_method! {
         #[derive(Debug, Deserialize)]
         pub struct RpcAdversarialCheckStoreResponse(pub u64);
 
-        impl_!(RpcHandlerResult for RpcAdversarialCheckStoreResponse {});
+        impl RpcHandlerResult for RpcAdversarialCheckStoreResponse {}
 
         impl_!(RpcMethod for RpcAdversarialCheckStoreRequest {
             type Result = RpcAdversarialCheckStoreResponse;


### PR DESCRIPTION
Prior to this, you could only construct requests using the predefined types in `method::*`. https://github.com/near/near-jsonrpc-client-rs/commit/70f05ae20c672098a1c875a6c88759dbccf08b33 saw the introduction of support for legacy patterns (behind a feature flag, of course).

This extends that capability to support generic method names. In the case where the method name doesn't exist, we return a  [`RpcRequestValidationErrorKind::MethodNotFound`](https://github.com/near/nearcore/blob/master/chain/jsonrpc-primitives/src/errors.rs#L39).

#### `#[cfg(features = "legacy")]`
`legacy`: `client.call(methods::block::by_id(id))`
`legacy`: `client.call(methods::query::by_path(path, data))`

#### `#[cfg(features = "all")]`
`all`: `client.call(methods::all("block", json!([id])))`
`all`: `client.call(methods::all("query", json!([path, data])))`