### PR TITLE
feat: impl smarter Any result descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ impl methods::RpcHandlerResponse for PartialGenesisConfig {}
 
 let mainnet_client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
 
-let genesis_config_request =
-    methods::any::<(PartialGenesisConfig, ())>("EXPERIMENTAL_genesis_config", json!(null));
+let genesis_config_request = methods::any::<Result<PartialGenesisConfig, ()>>(
+    "EXPERIMENTAL_genesis_config",
+    json!(null),
+);
 
 let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ impl methods::RpcHandlerResponse for PartialGenesisConfig {}
 let mainnet_client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
 
 let genesis_config_request =
-    methods::any::<PartialGenesisConfig, ()>("EXPERIMENTAL_genesis_config", json!(null));
+    methods::any::<(PartialGenesisConfig, ())>("EXPERIMENTAL_genesis_config", json!(null));
 
 let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //!    let mainnet_client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
 //!
 //!    let genesis_config_request =
-//!        methods::any::<PartialGenesisConfig, ()>("EXPERIMENTAL_genesis_config", json!(null));
+//!        methods::any::<(PartialGenesisConfig, ())>("EXPERIMENTAL_genesis_config", json!(null));
 //!
 //!    let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,10 @@
 //!    # async fn main() -> Result<(), JsonRpcError<()>> {
 //!    let mainnet_client = JsonRpcClient::connect("https://rpc.mainnet.near.org");
 //!
-//!    let genesis_config_request =
-//!        methods::any::<(PartialGenesisConfig, ())>("EXPERIMENTAL_genesis_config", json!(null));
+//!    let genesis_config_request = methods::any::<Result<PartialGenesisConfig, ()>>(
+//!        "EXPERIMENTAL_genesis_config",
+//!        json!(null),
+//!    );
 //!
 //!    let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 //!

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -135,17 +135,20 @@ mod shared_impls {
 }
 
 #[cfg(feature = "any")]
-pub use any::new as any;
+pub use any::request as any;
 
 #[cfg(feature = "any")]
 mod any {
     use super::*;
     use std::marker::PhantomData;
 
-    pub fn new<T, E>(method_name: &str, params: serde_json::Value) -> RpcAnyRequest<T, E>
+    pub fn request<T: AnyRequestResult>(
+        method_name: &str,
+        params: serde_json::Value,
+    ) -> RpcAnyRequest<T::Response, T::Error>
     where
-        T: RpcHandlerResponse,
-        E: RpcHandlerError,
+        T::Response: RpcHandlerResponse,
+        T::Error: RpcHandlerError,
     {
         RpcAnyRequest {
             method: method_name.to_string(),
@@ -179,6 +182,21 @@ mod any {
         fn params(&self) -> Result<serde_json::Value, io::Error> {
             Ok(self.params.clone())
         }
+    }
+
+    pub trait AnyRequestResult {
+        type Response;
+        type Error;
+    }
+
+    impl<T, E> AnyRequestResult for (T, E) {
+        type Response = T;
+        type Error = E;
+    }
+
+    impl<T: RpcMethod> AnyRequestResult for T {
+        type Response = T::Response;
+        type Error = T::Error;
     }
 }
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -189,7 +189,7 @@ mod any {
         type Error;
     }
 
-    impl<T, E> AnyRequestResult for (T, E) {
+    impl<T, E> AnyRequestResult for Result<T, E> {
         type Response = T;
         type Error = E;
     }


### PR DESCRIPTION
Impl smarter Any, providing a generic path for constructing requests + response/error deserialization

### Example: Mocking `block_by_id`

#### Before (had to explicitly provide info about the result)

```rust
let result = client.call(methods::any::<
    methods::block::RpcBlockResponse,
    methods::block::RpcBlockError,
>("block", json!([BlockId::Height(0)])));
```

#### With this PR, you can provide a descriptor

- One option, is an already well-defined `RpcMethod`
  This would use the predefined `RpcMethod::Response` and `RpcMethod::Error` types. Which, more or less expands to the example above.

  ```rust
  let result = client.call(methods::any::<methods::block::RpcBlockResult>(
      "block",
      json!([BlockId::Height(0)]),
  ));
  ```
- Another option, offering flexibility, is a custom result + error type.

  ```rust
  #[derive(Deserialize)]
  struct CustomBlockLookupResult {
      author: AccountId,
  }

  let result = client.call(methods::any::<(
      CustomBlockLookupResult,
      methods::block::RpcBlockError,
  )>("block", json!([BlockId::Height(0)])));
  ```