### PR TITLE
feat: add support for basic authentication tokens

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,8 +47,8 @@ pub enum JsonRpcServerResponseStatusError {
     Unauthorized,
     #[error("this client has exceeded the rate limit")]
     TooManyRequests,
-    #[error("the server returned a non-OK (200) status code: [{0}]")]
-    Unexpected(reqwest::StatusCode),
+    #[error("the server returned a non-OK (200) status code: [{status}]")]
+    Unexpected { status: reqwest::StatusCode },
 }
 
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,9 @@ impl JsonRpcClient {
                         reqwest::StatusCode::TOO_MANY_REQUESTS => {
                             JsonRpcServerResponseStatusError::TooManyRequests
                         }
-                        unexpected => JsonRpcServerResponseStatusError::Unexpected(unexpected),
+                        unexpected => {
+                            JsonRpcServerResponseStatusError::Unexpected { status: unexpected }
+                        }
                     }),
                 ));
             }


### PR DESCRIPTION
RPC Authorization is underway. This adds support for the use of basic auth tokens and impl reporting unauthorized requests.

### Syntax

```rust
// start by creating an unauthenticated client
let unauthenticated_client = JsonRpcClient::connect("https://rpc.mainnnet.near.org");

// depending on the server, you can then use this just fine with no need for explicit authentication

unauthenticated_client.call(methods::...).await?;

// you can transition to an authenticated client by handing the credentials to the `.auth()` method

let authenticated_client = unauthenticated_client.auth(ClientCredentials::Basic(
    "<basic authentication token>".to_string(), // not base64..
));

authenticated_client.call(methods::...).await?;
```