### PR TITLE
refactor!: impl statefully typed API design around authentication

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -25,18 +25,24 @@ pub trait AuthScheme {
 }
 
 #[derive(Debug, Clone)]
-pub struct Authenticated<T>(pub(crate) T);
+pub struct Authenticated<T> {
+    pub(crate) auth_scheme: T,
+}
+
 impl<T: AuthScheme> AuthState for Authenticated<T> {}
 impl<T: AuthScheme> private::AuthState for Authenticated<T> {
     fn maybe_credentials(&self) -> Option<ClientCredentials> {
-        Some(self.0.credentials())
+        Some(self.auth_scheme.credentials())
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct BasicAuth(pub String);
+pub struct BasicAuth {
+    pub credentials: String,
+}
+
 impl AuthScheme for BasicAuth {
     fn credentials(&self) -> ClientCredentials {
-        ClientCredentials::Basic(&self.0)
+        ClientCredentials::Basic(&self.credentials)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl JsonRpcClient<Unauthenticated> {
     pub fn auth<T: AuthScheme>(self, auth_scheme: T) -> JsonRpcClient<Authenticated<T>> {
         JsonRpcClient {
             inner: self.inner,
-            auth_state: Authenticated(auth_scheme),
+            auth_state: Authenticated { auth_scheme },
         }
     }
 }


### PR DESCRIPTION
Refactor to encode authentication state in the type system itself.

By default, `JsonRpcClient::connect("localhost:3030")` returns an unauthenticated client, which is represented by `JsonRpcClient<Unauthenticated>`.. Only for that type, we have `::basic_auth()` implemented, which morphs it into a `JsonRpcClient<Authenticated<BasicAuth>>`.


This helps disambiguate authentication states at compile time and maybe in the future, we can encode more complex logic like, methods that are only callable when the client is authenticated.

This also dissociates the logic for types of authentication. Currently, we have just basic auth implemented, but in the future with JWTs, we could have login-like functionality or simple token passing. Depending on the implementation, this could be fallible, but in this case, each method would have its own authentication implementation.

```rust
let client = JsonRpcClient::connect() -> JsonRpcClient<Unauthenticated>
client.auth(auth::BasicAuth { credentials: "secret" }) -> JsonRpcClient<Authenticated<BasicAuth>>

// future
client.login(Credentials { .. }).await -> Result<JsonRpcClient<Authenticated<..>>, LoginFailed>
client.token_auth("token") -> JsonRpcClient<Authenticated<..>>
```

*<sub>Inspired by this amazing talk by Will Crichton <https://www.youtube.com/watch?v=bnnacleqg6k></sub>*