### PR TITLE
feat: make auth interface more generic

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use near_primitives::serialize::to_base64;
 
 pub struct AuthHeaderEntry {
@@ -38,10 +40,19 @@ impl<T: AuthScheme> private::AuthState for Authenticated<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ApiKey {
     Plain(String),
     Base64(String),
+}
+
+impl fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApiKey::Plain(s) => f.debug_tuple("ApiKey::Plain").field(s).finish(),
+            ApiKey::Base64(s) => f.debug_tuple("ApiKey::Base64").field(s).finish(),
+        }
+    }
 }
 
 impl AuthScheme for ApiKey {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,11 +1,13 @@
-#[derive(Eq, Clone, Debug, PartialEq)]
-pub enum ClientCredentials<'a> {
-    Basic(&'a str),
+use near_primitives::serialize::to_base64;
+
+pub struct AuthHeaderEntry {
+    pub header: String,
+    pub value: String,
 }
 
 mod private {
     pub trait AuthState {
-        fn maybe_credentials(&self) -> Option<super::ClientCredentials>;
+        fn maybe_auth_header(&self) -> Option<super::AuthHeaderEntry>;
     }
 }
 
@@ -15,13 +17,13 @@ pub trait AuthState: private::AuthState {}
 pub struct Unauthenticated;
 impl AuthState for Unauthenticated {}
 impl private::AuthState for Unauthenticated {
-    fn maybe_credentials(&self) -> Option<ClientCredentials> {
+    fn maybe_auth_header(&self) -> Option<AuthHeaderEntry> {
         None
     }
 }
 
 pub trait AuthScheme {
-    fn credentials(&self) -> ClientCredentials;
+    fn get_auth_header(&self) -> AuthHeaderEntry;
 }
 
 #[derive(Debug, Clone)]
@@ -31,18 +33,25 @@ pub struct Authenticated<T> {
 
 impl<T: AuthScheme> AuthState for Authenticated<T> {}
 impl<T: AuthScheme> private::AuthState for Authenticated<T> {
-    fn maybe_credentials(&self) -> Option<ClientCredentials> {
-        Some(self.auth_scheme.credentials())
+    fn maybe_auth_header(&self) -> Option<AuthHeaderEntry> {
+        Some(self.auth_scheme.get_auth_header())
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct BasicAuth {
-    pub credentials: String,
+pub enum ApiKey {
+    Plain(String),
+    Base64(String),
 }
 
-impl AuthScheme for BasicAuth {
-    fn credentials(&self) -> ClientCredentials {
-        ClientCredentials::Basic(&self.credentials)
+impl AuthScheme for ApiKey {
+    fn get_auth_header(&self) -> AuthHeaderEntry {
+        AuthHeaderEntry {
+            header: "x-api-key".to_string(),
+            value: match self {
+                ApiKey::Plain(ref token) => to_base64(token),
+                ApiKey::Base64(ref token) => token.clone(),
+            },
+        }
     }
 }


### PR DESCRIPTION
This makes the auth interface more generic, primarily to extend the flexibility of custom implementations. Allowing them to be able to customize their header names.

```rust
use near_jsonrpc_client::auth;

struct CustomUserAuth {
    username: String,
    password: zeroize::Zeroizing<String>
}

impl auth::AuthScheme for CustomUserAuth {
    fn get_auth_header(&self) -> auth::AuthHeaderEntry {
        auth::AuthHeaderEntry {
            header: "Authorization".to_string(),
            token: format!("Basic {}", base64::encode(format!("{}:{}", self.username, *self.password))),
        }
    }
}

let client = JsonRpcClient::connect("http://localhost:3030")
    .auth(CustomUserAuth { username: "root", password: "n1c3_try".to_string().into() });
```

Also replaces `Authorization: Basic <token>` with `x-api-key: <token>`.

```rust
let client = JsonRpcClient::connect("http://localhost:3030")
    .auth(BasicAuth { token: "our-secret-token" });
```

Now becomes;

1. ```rust
    let client = JsonRpcClient::connect("http://localhost:3030")
        .auth(ApiKey::Plain("our-secret-token"));
    ```

    > \- or -

2. ```rust
    let client = JsonRpcClient::connect("http://localhost:3030")
        .auth(ApiKey::Base64("b3VyLXNlY3JldC10b2tlbg=="));
    ```