### PR TITLE
bump crate version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ borsh = "0.9"
 serde = "1.0.127"
 serde_json = "1.0.66"
 
-near-primitives = "0.10.0"
-near-chain-configs = "0.10.0"
-near-client-primitives = "0.10.0"
-near-jsonrpc-primitives = "0.10.0"
+near-primitives = "0.11.0"
+near-chain-configs = "0.11.0"
+near-client-primitives = "0.11.0"
+near-jsonrpc-primitives = "0.11.0"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/near-jsonrpc-client-rs"
-homepage = "https://github.com/near/near-jsonrpc-client-rs"
 description = "Lower-level API for interfacing with the NEAR Protocol via JSONRPC"
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "api", "jsonrpc", "rpc", "async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1.0.66"
 
 near-primitives = "0.11.0"
 near-chain-configs = "0.11.0"
-near-client-primitives = "0.11.0"
 near-jsonrpc-primitives = "0.11.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 [![crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.1.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.1.0)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.1.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.2.0)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 
 [![crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
-[![Version](https://img.shields.io/badge/rustc-1.56+-ab6000.svg)](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)
 [![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.1.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.1.0)
 

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -468,9 +468,7 @@ impl_method! {
 
 impl_method! {
     pub mod network_info {
-        pub use near_jsonrpc_primitives::types::network_info::RpcNetworkInfoError;
-
-        pub type RpcNetworkInfoResponse = near_client_primitives::types::NetworkInfoResponse;
+        pub use near_jsonrpc_primitives::types::network_info::{RpcNetworkInfoError, RpcNetworkInfoResponse};
 
         #[derive(Debug)]
         pub struct RpcNetworkInfoRequest;


### PR DESCRIPTION
- Update nearcore version to `0.11.0` (https://github.com/near/nearcore/pull/5943).
- Fixed `chunk` method serialization. https://github.com/near/near-jsonrpc-client-rs/commit/f40ad743653ad2a1a9eb5eaa96c302c9b531bf40
- `Client::call` no longer consumes the client. https://github.com/near/near-jsonrpc-client-rs/commit/471a53be062e0880c6bc5c2721d123da2a9e0c2e
- Implemented workaround for partially serialized server responses. https://github.com/near/near-jsonrpc-client-rs/pull/29
- Dropped base64 api token support in favor of a generic key-value approach. https://github.com/near/near-jsonrpc-client-rs/commit/dd7761b51e1775350be1782370aa22c0b0fe98d7