### PR TITLE
ensure None-typed errors are actual errors (displayable, etc.)

### DIFF
--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,6 +1,8 @@
 use std::io;
 
+use serde::Deserialize;
 use serde_json::json;
+use thiserror::Error;
 
 mod chk {
     // this lets us make the RpcMethod trait public but non-implementable by users outside this crate
@@ -111,7 +113,8 @@ macro_rules! parse_unknown_block {
 mod shared_impls {
     use super::{RpcHandlerError, RpcHandlerResponse};
 
-    // broadcast_tx_async, EXPERIMENTAL_genesis_config, adv_*
+    // adv_*
+    #[cfg(feature = "adversarial")]
     impl RpcHandlerError for () {}
 
     // adv_*
@@ -293,11 +296,17 @@ impl_method! {
             }
         }
 
+        #[derive(Debug, Deserialize, Error)]
+        #[error("{}", unreachable!("fatal: this error should never constructed"))]
+        pub enum RpcBroadcastTxAsyncError {}
+
         impl RpcHandlerResponse for RpcBroadcastTxAsyncResponse {}
+
+        impl RpcHandlerError for RpcBroadcastTxAsyncError {}
 
         impl_!(RpcMethod for RpcBroadcastTxAsyncRequest {
             type Response = RpcBroadcastTxAsyncResponse;
-            type Error = ();
+            type Error = RpcBroadcastTxAsyncError;
 
             fn params(&self) -> Result<serde_json::Value, io::Error> {
                 Ok(json!([serialize_signed_transaction(&self.signed_transaction)?]))
@@ -705,11 +714,17 @@ impl_method! {
         #[derive(Debug)]
         pub struct RpcGenesisConfigRequest;
 
+        #[derive(Debug, Deserialize, Error)]
+        #[error("{}", unreachable!("fatal: this error should never constructed"))]
+        pub enum RpcGenesisConfigError {}
+
         impl RpcHandlerResponse for RpcGenesisConfigResponse {}
+
+        impl RpcHandlerError for RpcGenesisConfigError {}
 
         impl_!(RpcMethod for RpcGenesisConfigRequest {
             type Response = RpcGenesisConfigResponse;
-            type Error = ();
+            type Error = RpcGenesisConfigError;
 
             fn params(&self) -> Result<serde_json::Value, io::Error> {
                 Ok(json!(null))


### PR DESCRIPTION
A couple of RPC methods do not have an error equivalent. Notably: `broadcast_tx_async`, `EXPERIMENTAL_genesis_config` and adversarial methods. In each case, we use the unit `()` type to signify the absense of an error type.

But this is insufficient. Particularly given the fact that `std::error::Error` hinges on `fmt::Display` which requires each handler error to be itself `fmt::Display`-able. Which is not the case with `()`.

This PR implements a workaround by using a custom, non-constructable unit type with a custom `fmt::Display` implementation that would never be called. If ever, that results in a hard error.