### PR TITLE
feat: JsonRpcClient, default to Unauthenticated state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ impl JsonRpcClientConnector {
 
 /// A NEAR JSON RPC Client.
 #[derive(Clone)]
-pub struct JsonRpcClient<A> {
+pub struct JsonRpcClient<A = Unauthenticated> {
     inner: Arc<JsonRpcInnerClient>,
     auth_state: A,
 }


### PR DESCRIPTION
Default the `JsonRpcClient`'s authentication state to being `Unauthenticated`, much like `HashMap`'s `RandomState`. Makes it so you don't have to worry about authentication until you actually need to. So the `auth` module shouldn't be imported without you doing any authentication.

##### Diff

```diff
-use near_jsonrpc_client::{auth, JsonRpcClient};
+use near_jsonrpc_client::JsonRpcClient;

struct App {
-    client: JsonRpcClient<auth::Unauthenticated>, // <-- pain
+    client: JsonRpcClient,
}

enum Network {
    MainNet,
    TestNet,
}

- fn mk_client(network: Network) -> JsonRpcClient<auth::Unauthenticated> { // <-- pain
+ fn mk_client(network: Network) -> JsonRpcClient {
    let rpc_url = match network {
        Network::MainNet => "https://rpc.mainnet.near.org",
        Network::TestNet => "https://rpc.testnet.near.org",
    };
    JsonRpcClient::connect(rpc_url)
}
```