### PR TITLE
feat(sandbox): impl client support for fast forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Dropped generic authentication and added support for custom headers. <https://github.com/near/near-jsonrpc-client-rs/pull/47>
+- Added the `sandbox_fast_forward` RPC Method. <https://github.com/near/near-jsonrpc-client-rs/pull/38>
 - Executing the [examples](https://github.com/near/near-jsonrpc-client-rs/tree/master/examples) now allows custom RPC addr specification with interactive server selection. <https://github.com/near/near-jsonrpc-client-rs/commit/b130118d0de806bd9950be306f563559f07c77e6> <https://github.com/near/near-jsonrpc-client-rs/commit/c5e938a90703cb216e99d6f23a43ad9d3812df3d>
 - `JsonRpcClient::connect` is now generic over any url-like type. [`Url`](https://docs.rs/url/*/url/struct.Url.html), `&str`, `String` and `&String` are all supported. <https://github.com/near/near-jsonrpc-client-rs/pull/35>
 - `JsonRpcClient` now defaults to the `Unauthenticated` state, easing a type specification pain point. <https://github.com/near/near-jsonrpc-client-rs/pull/36>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ borsh = "0.9"
 serde = "1.0.127"
 serde_json = "1.0.66"
 
-near-primitives = "0.11.0"
-near-chain-configs = "0.11.0"
-near-jsonrpc-primitives = "0.11.0"
+near-primitives = "0.0.0"
+near-chain-configs = "0.0.0"
+near-jsonrpc-primitives = "0.0.0"
 
 [dev-dependencies]
 near-crypto = "0.11.0"
@@ -32,3 +32,8 @@ tokio = { version = "1.1", features = ["rt", "macros"] }
 any = []
 sandbox = []
 adversarial = []
+
+[patch.crates-io]
+near-primitives = { git = "https://github.com/near/nearcore", branch = "phuong/sandbox-fast-forwarding" }
+near-chain-configs = { git = "https://github.com/near/nearcore", branch = "phuong/sandbox-fast-forwarding" }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", branch = "phuong/sandbox-fast-forwarding" }

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -867,6 +867,29 @@ impl_method! {
     }
 }
 
+#[cfg(feature = "sandbox")]
+impl_method! {
+    pub mod sandbox_fast_forward {
+        pub use near_jsonrpc_primitives::types::sandbox::{
+            RpcSandboxFastForwardError, RpcSandboxFastForwardRequest,
+            RpcSandboxFastForwardResponse,
+        };
+
+        impl RpcHandlerResponse for RpcSandboxFastForwardResponse {}
+
+        impl RpcHandlerError for RpcSandboxFastForwardError {}
+
+        impl_!(RpcMethod for RpcSandboxFastForwardRequest {
+            type Response = RpcSandboxFastForwardResponse;
+            type Error = RpcSandboxFastForwardError;
+
+            fn params(&self) -> Result<serde_json::Value, io::Error> {
+                Ok(json!(self))
+            }
+        });
+    }
+}
+
 #[cfg(feature = "adversarial")]
 impl_method! {
     pub mod adv_set_weight {


### PR DESCRIPTION
After https://github.com/near/nearcore/pull/6158, neard client supports fast forwarding to a specific height. This implements client support for that.

```rust
let client = JsonRpcClient::connect("http://localhost:3030");

client.call(
    methods::sandbox_fast_forward::RpcSandboxFastForwardRequest {
        delta_height: 10_000,
    },
);
```

Translates directly to 👇🏽 

```console
xh http://localhost:3030 \
  jsonrpc=2.0 id=dontcare \
  method=sandbox_fast_forward params:='{ "delta_height": 10000 }'
```