### PR TITLE
chore(ci): skip rust installation in rustdoc pipeline

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -2,29 +2,21 @@ name: rustdoc
 
 on:
   push:
-    branches:
-    - master
+    branches: [ master ]
 
 env:
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
   RUSTFLAGS: -D warnings
-  RUSTUP_MAX_RETRIES: 10
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
 
 jobs:
   rustdoc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
-
-    - name: Install Rust Toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        default: true
 
     - name: Build Documentation
       run: |


### PR DESCRIPTION
First, we stick to using the `ubuntu-20.04` image, and then, according to https://github.com/actions/virtual-environments/blob/e5d8f5af5c5dfef051432b3cd33d5078331cc1b5/images/linux/Ubuntu2004-Readme.md#rust-tools;

> ### Rust Tools
>  - Cargo 1.58.0
>  - Rust 1.58.1
>  - Rustdoc 1.58.1
>  - Rustup 1.24.3

Rust is already preinstalled right out of the box for this image, so we can skip the installation step.