### PR TITLE
feat(infra): introduce automated publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
         tag_name: ${{ env.GIT_LATEST_TAG }}
         release_name: ${{ env.GIT_LATEST_TAG }}
         body: |
+          ## What's changed?
+        
           ${{ steps.extract-release-notes.outputs.release_notes }}
 
           **Crate Link**: ${{ steps.tag-and-publish.outputs.git_tag_message }}
+
+          **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ env.GIT_PREVIOUS_TAG }}...${{ env.GIT_LATEST_TAG }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  RUSTFLAGS: -D warnings
+  RUST_BACKTRACE: short
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Show Active Rust Toolchain
+      run: rustup show active-toolchain
+
+    - name: Run cargo test
+      run: cargo test --verbose --workspace
+
+  clippy:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Run clippy
+      run: cargo clippy -- -D clippy::all
+
+  cargo-fmt:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Run cargo fmt
+      run: cargo fmt --all -- --check
+
+  publish:
+    runs-on: ubuntu-20.04
+    needs: [tests, clippy, cargo-fmt]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        # fetch tags for cargo ws publish
+        # might be a simple `fetch-tags: true` option soon, see https://github.com/actions/checkout/pull/579
+        fetch-depth: 0
+
+    - name: Setup
+      run: |
+        git config user.name github-actions
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        cargo install --git https://github.com/miraclx/cargo-workspaces --rev b2d49b9e575e29fd2395352e4d0df47def025039 cargo-workspaces
+        export GIT_PREVIOUS_TAG=$(git describe --tags --abbrev=0)
+        echo "GIT_PREVIOUS_TAG=${GIT_PREVIOUS_TAG}" >> $GITHUB_ENV
+        echo "[ pre run] current latest git tag is \"${GIT_PREVIOUS_TAG}\""
+
+    - name: Publish to crates.io and tag the commit
+      id: tag-and-publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        cargo ws publish --all --yes --exact \
+          --skip-published --no-git-commit --allow-dirty \
+          --tag-existing --tag-prefix 'v' \
+          --tag-msg 'crates.io snapshot' --tag-msg '%{https://crates.io/crates/%n/%v}' \
+          --no-individual-tags --no-git-push
+        export GIT_LATEST_TAG=$(git describe --tags --abbrev=0)
+        echo "GIT_LATEST_TAG=${GIT_LATEST_TAG}" >> $GITHUB_ENV
+        echo "[post run] current latest git tag is \"${GIT_LATEST_TAG}\""
+        echo "::set-output name=tagged::$( [[ "$GIT_LATEST_TAG" == "$GIT_PREVIOUS_TAG" ]] && echo 0 || echo 1 )"
+
+        # returning multi-line outputs gets truncated to include only the first line
+        # we have to escape the newline chars, runner auto unescapes them later
+        # https://github.community/t/set-output-truncates-multiline-strings/16852/3
+        GIT_TAG_MESSAGE="$(git tag -l --format='%(body)' ${GIT_LATEST_TAG})"
+        GIT_TAG_MESSAGE="${GIT_TAG_MESSAGE//'%'/'%25'}"
+        GIT_TAG_MESSAGE="${GIT_TAG_MESSAGE//$'\n'/'%0A'}"
+        GIT_TAG_MESSAGE="${GIT_TAG_MESSAGE//$'\r'/'%0D'}"
+        echo "::set-output name=git_tag_message::${GIT_TAG_MESSAGE}"
+
+    - name: Push tags to GitHub (if any)
+      if: steps.tag-and-publish.outputs.tagged == 1
+      run: git push --tags
+
+    - name: Extract release notes
+      if: steps.tag-and-publish.outputs.tagged == 1
+      id: extract-release-notes
+      uses: ffurrer2/extract-release-notes@c24866884b7a0d2fd2095be2e406b6f260479da8
+
+    - name: Create release
+      if: steps.tag-and-publish.outputs.tagged == 1
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.GIT_LATEST_TAG }}
+        release_name: ${{ env.GIT_LATEST_TAG }}
+        body: |
+          ${{ steps.extract-release-notes.outputs.release_notes }}
+
+          **Crate Link**: ${{ steps.tag-and-publish.outputs.git_tag_message }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.2.0"
+version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,6 +9,10 @@ description = "Lower-level API for interfacing with the NEAR Protocol via JSONRP
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "api", "jsonrpc", "rpc", "async"]
 rust-version = "1.56.0"
+
+# cargo-workspaces
+[workspace.metadata.workspaces]
+version = "0.2.0"
 
 [dependencies]
 thiserror = "1.0.28"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 println!("{:#?}", partial_genesis);
 ```
 
+## Releasing
+
+Versioning and releasing of this crate is automated and managed by [custom fork](https://github.com/miraclx/cargo-workspaces/tree/grouping-versioning-and-exclusion) of [`cargo-workspaces`](https://github.com/pksunkara/cargo-workspaces). To publish a new version of this crate, you can do so by bumping the `version` under the `[workspace.metadata.workspaces]` section in the [package manifest](https://github.com/near/near-jsonrpc-client-rs/blob/master/Cargo.toml) and submit a PR.
+
+We have CI Infrastructure put in place to automate the process of publishing all crates once a version change has merged into master.
+
+However, before you release, make sure the [CHANGELOG](https://github.com/near/near-jsonrpc-client-rs/blob/master/CHANGELOG.md) is up to date and that the `[Unreleased]` section is present but empty.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as below, without any additional terms or conditions.
+
 ## License
 
 Licensed under either of
@@ -91,9 +105,3 @@ Licensed under either of
    ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
-
-## Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Following https://github.com/near/borsh-rs/pull/67, this PR introduces a CI job that automates versioning and publishing this crate to crates.io.

#### Here's what the tag page should look like:

<img width="500" src="https://user-images.githubusercontent.com/16881812/151576444-69551172-43f3-42a1-a116-478db86d20ff.png"/>

#### Here's what the release page should look like:

![Screenshot_20220128_164341](https://user-images.githubusercontent.com/16881812/151577088-caf3701f-579f-4bf4-a895-34be61623068.png)