### PR TITLE
drop unnecessary explicit generic specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Executing the [examples](https://github.com/near/near-jsonrpc-client-rs/tree/master/examples) now allows custom RPC addr specification with interactive server selection. <https://github.com/near/near-jsonrpc-client-rs/commit/b130118d0de806bd9950be306f563559f07c77e6> <https://github.com/near/near-jsonrpc-client-rs/commit/c5e938a90703cb216e99d6f23a43ad9d3812df3d>
-- `JsonRpcClient::connect` is now generic over any string-like type. `&str`, `String` and `&String` are all supported. <https://github.com/near/near-jsonrpc-client-rs/pull/35>
+- `JsonRpcClient::connect` is now generic over any string-like type. `&str`, `String` and `&String` are all supported. <https://github.com/near/near-jsonrpc-client-rs/pull/35> <https://github.com/near/near-jsonrpc-client-rs/pull/42>
 - `JsonRpcClient` now defaults to the `Unauthenticated` state, easing a type specification pain point. <https://github.com/near/near-jsonrpc-client-rs/pull/36>
 
 ## [0.2.0] - 2021-12-22

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub struct JsonRpcClientConnector {
 
 impl JsonRpcClientConnector {
     /// Return an unauthenticated JsonRpcClient that connects to the specified server.
-    pub fn connect<U: AsUrl>(&self, server_addr: U) -> JsonRpcClient<Unauthenticated> {
+    pub fn connect(&self, server_addr: impl AsUrl) -> JsonRpcClient<Unauthenticated> {
         JsonRpcClient {
             inner: Arc::new(JsonRpcInnerClient {
                 server_addr: server_addr.to_string(),
@@ -196,7 +196,7 @@ impl JsonRpcClient<Unauthenticated> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn connect<U: AsUrl>(server_addr: U) -> JsonRpcClient<Unauthenticated> {
+    pub fn connect(server_addr: impl AsUrl) -> JsonRpcClient<Unauthenticated> {
         DEFAULT_CONNECTOR.connect(server_addr)
     }
 


### PR DESCRIPTION
```rust
fn connect::<T: Trait>(arg: T) {}
```

vs.

```rust
fn connect(arg: impl Trait) {}
```

where `Trait` is a sealed trait, implemented for specific types - `A`, `B` and `C`.

I don't see any real use for the generic `T`. Or am I missing something?