### PR TITLE
chore(docs): document tx jsonrpc method

### DIFF
--- a/src/methods/tx.rs
+++ b/src/methods/tx.rs
@@ -1,3 +1,29 @@
+//! This module allows you to query the status of a transaction signed by an account_id
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_jsonrpc_primitives::types::transactions::TransactionInfo;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//! let tx_hash = "B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq".parse()?;
+//!
+//! let request = methods::tx::RpcTransactionStatusRequest {
+//!     transaction_info: TransactionInfo::TransactionId {
+//!         hash: tx_hash,
+//!         account_id: "itranscend.near".parse()?,
+//!    }
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert_eq!(tx_hash, response.transaction.hash);
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::transactions::RpcTransactionError;


### PR DESCRIPTION
Documented the `tx` RPC method, including an easy to understand example.