### PR TITLE
docs.rs: document the `any` helper and `sandbox` RPC methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ tokio = { version = "1.1", features = ["rt", "macros"] }
 any = []
 sandbox = []
 adversarial = []
+
+[package.metadata.docs.rs]
+features = ["any", "sandbox"]


### PR DESCRIPTION
Current (`v0.3.0`) build of the doc on docs.rs – https://docs.rs/near-jsonrpc-client/0.3.0/near_jsonrpc_client/methods/index.html doesn't include any sandbox methods or the “any” helper function. This remedies that.

However, this **still** excludes all adversarial methods.