### PR TITLE
chore: move auth-specific logic behind the default `auth` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,13 @@ rust-version = "1.56.0"
 version = "0.3.0"
 
 [dependencies]
-thiserror = "1.0.28"
-
-reqwest = { version = "0.11.4", features = ["json"] }
-lazy_static = "1.4.0"
-
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"], optional = true }
 borsh = "0.9"
 serde = "1.0.127"
+reqwest = { version = "0.11.4", features = ["json"] }
+thiserror = "1.0.28"
 serde_json = "1.0.66"
+lazy_static = "1.4.0"
 
 near-primitives = "0.12.0"
 near-chain-configs = "0.12.0"
@@ -34,9 +32,15 @@ near-crypto = "0.12.0"
 tokio = { version = "1.1", features = ["rt", "macros"] }
 
 [features]
+default = ["auth"]
 any = []
+auth = ["uuid"]
 sandbox = []
 adversarial = []
 
+[[example]]
+name = "auth"
+required-features = ["auth"]
+
 [package.metadata.docs.rs]
-features = ["any", "sandbox"]
+features = ["any", "auth", "sandbox"]

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use near_jsonrpc_client::{auth, JsonRpcClient};
+use near_jsonrpc_client::JsonRpcClient;
 use std::io::{self, Write};
 
 pub fn input(query: &str) -> io::Result<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ use lazy_static::lazy_static;
 
 use near_jsonrpc_primitives::message::{from_slice, Message};
 
+#[cfg(feature = "auth")]
 pub mod auth;
 pub mod errors;
 pub mod header;
@@ -277,18 +278,18 @@ impl JsonRpcClient {
     /// ### Example
     ///
     /// ```
+    /// # #[cfg(feature = "auth")]
     /// use near_jsonrpc_client::{auth, JsonRpcClient};
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = JsonRpcClient::connect("https://rpc.testnet.near.org")
-    ///     .header(
-    ///         auth::ApiKey::new("cadc4c83-5566-4c94-aa36-773605150f44")? // <- error handling here
-    ///     ) // <- returns the client
-    ///     .header(
-    ///         ("user-agent", "someclient/0.1.0")
-    ///     )? // <- error handling here, returned a result
-    /// # ;
+    /// let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+    /// let client = client.header(("user-agent", "someclient/0.1.0"))?; // <- returns a result
+    ///
+    /// # #[cfg(feature = "auth")]
+    /// let client = client.header(
+    ///     auth::ApiKey::new("cadc4c83-5566-4c94-aa36-773605150f44")?, // <- error handling here
+    /// ); // <- returns the client
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,13 +278,15 @@ impl JsonRpcClient {
     /// ### Example
     ///
     /// ```
-    /// # #[cfg(feature = "auth")]
-    /// use near_jsonrpc_client::{auth, JsonRpcClient};
+    /// use near_jsonrpc_client::JsonRpcClient;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
     /// let client = client.header(("user-agent", "someclient/0.1.0"))?; // <- returns a result
+    ///
+    /// # #[cfg(feature = "auth")]
+    /// use near_jsonrpc_client::auth;
     ///
     /// # #[cfg(feature = "auth")]
     /// let client = client.header(


### PR DESCRIPTION
Introduce the `auth` feature flag (selected by default), making the `uuid` dependency conditionally optional.