### PR TITLE
chore(docs): document the `status` RPC method

### DIFF
--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -15,10 +15,9 @@
 //!
 //! let response = client.call(request).await;
 //!
-//! assert!(
-//!     matches!(
-//!         response,
-//!         Ok(methods::status::RpcStatusResponse { .. })
+//! assert!(matches!(
+//!     response,
+//!     Ok(methods::status::RpcStatusResponse { .. })
 //! ));
 //! # Ok(())
 //! # }

--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -1,8 +1,9 @@
-//! Queries the status of a given node
+//! Requests the status of the connected RPC node.
 //!
-//! Returns the general status of a given node (sync status, nearcore node version, protocol version, etc), and the current set of validators.
+//! Returns the status of the connected RPC node (sync status, nearcore node version, protocol version, etc), and the current set of validators.
 //!
 //! ## Example
+//!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
@@ -15,11 +16,10 @@
 //! let response = client.call(request).await;
 //!
 //! assert!(
-//!     matches!(response, Ok(methods::status::RpcStatusResponse { .. })),
-//!     "expected an Ok(RpcStatusResponse) but got [{:?}]",
-//!     response
-//! );
-//!
+//!     matches!(
+//!         response,
+//!         Ok(methods::status::RpcStatusResponse { .. })
+//! ));
 //! # Ok(())
 //! # }
 //! ```

--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -1,3 +1,28 @@
+//! Queries the status of a given node
+//!
+//! Returns the general status of a given node (sync status, nearcore node version, protocol version, etc), and the current set of validators.
+//!
+//! ## Example
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!
+//! let request = methods::status::RpcStatusRequest;
+//!
+//! let response = client.call(request).await;
+//!
+//! assert!(
+//!     matches!(response, Ok(methods::status::RpcStatusResponse { .. })),
+//!     "expected an Ok(RpcStatusResponse) but got [{:?}]",
+//!     response
+//! );
+//!
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::status::RpcStatusError;

--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -13,11 +13,11 @@
 //!
 //! let request = methods::status::RpcStatusRequest;
 //!
-//! let response = client.call(request).await;
+//! let response = client.call(request).await?;
 //!
 //! assert!(matches!(
 //!     response,
-//!     Ok(methods::status::RpcStatusResponse { .. })
+//!     methods::status::RpcStatusResponse { .. }
 //! ));
 //! # Ok(())
 //! # }

--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -1,6 +1,6 @@
 //! Requests the status of the connected RPC node.
 //!
-//! Returns the status of the connected RPC node (sync status, nearcore node version, protocol version, etc), and the current set of validators.
+//! This includes information about sync status, nearcore node version, protocol version, the current set of validators, etc.
 //!
 //! ## Example
 //!


### PR DESCRIPTION
Tracking issue: https://github.com/near/near-jsonrpc-client-rs/issues/51

Documented the `status` RPC method, including an easy-to-understand example.