### PR TITLE
chore(docs): document the `network_info` RPC method

### DIFF
--- a/src/methods/network_info.rs
+++ b/src/methods/network_info.rs
@@ -1,6 +1,6 @@
-//! Requests information about nodes on the network.
+//! Queries the current state of node network connections.
 //!
-//! Returns the current state of node network connections (active peers, transmitted data, received data, known producers, etc.).
+//! This includes information about active peers, transmitted data, known producers, etc.
 //!
 //! ## Example
 //!

--- a/src/methods/network_info.rs
+++ b/src/methods/network_info.rs
@@ -1,3 +1,28 @@
+//! Requests information about nodes on the network.
+//!
+//! Returns the current state of node network connections (active peers, transmitted data, received data, known producers, etc.).
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!
+//! let request = methods::network_info::RpcNetworkInfoRequest;
+//!
+//! let response = client.call(request).await;
+//!
+//! assert!(matches!(
+//!     response,
+//!     Ok(methods::network_info::RpcNetworkInfoResponse { .. })
+//! ));
+//!
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::network_info::{

--- a/src/methods/network_info.rs
+++ b/src/methods/network_info.rs
@@ -19,7 +19,6 @@
 //!     response,
 //!     Ok(methods::network_info::RpcNetworkInfoResponse { .. })
 //! ));
-//!
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
Tracking issue: https://github.com/near/near-jsonrpc-client-rs/issues/51

Documented the `network_info` RPC method, including an easy-to-understand example.