### PR TITLE
chore(docs): document the `health` RPC method

### DIFF
--- a/src/methods/health.rs
+++ b/src/methods/health.rs
@@ -1,3 +1,27 @@
+//! Requests health status of the rpc node.
+//!
+//! ## Example
+//!
+//! Returns the current health stauts of the rpc node it connects to.
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!
+//! let request = methods::health::RpcHealthRequest;
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     methods::health::RpcHealthResponse { .. }
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::status::{RpcHealthResponse, RpcStatusError};

--- a/src/methods/health.rs
+++ b/src/methods/health.rs
@@ -1,4 +1,4 @@
-//! Requests health status of the rpc node.
+//! Requests the health status of the rpc node.
 //!
 //! ## Example
 //!

--- a/src/methods/health.rs
+++ b/src/methods/health.rs
@@ -1,8 +1,8 @@
-//! Requests the health status of the rpc node.
+//! Requests the health status of the RPC node.
 //!
 //! ## Example
 //!
-//! Returns the current health stauts of the rpc node it connects to.
+//! Returns the current health stauts of the RPC node the client connects to.
 //!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
@@ -17,7 +17,7 @@
 //!
 //! assert!(matches!(
 //!     response,
-//!     methods::health::RpcHealthResponse { .. }
+//!     methods::health::RpcHealthResponse
 //! ));
 //! # Ok(())
 //! # }


### PR DESCRIPTION
Tracking issue: https://github.com/near/near-jsonrpc-client-rs/issues/51

Documented the `health` RPC method, including an easy-to-understand example.