### PR TITLE
chore(docs): document the experimental `tx_status` RPC method

### DIFF
--- a/src/methods/experimental/tx_status.rs
+++ b/src/methods/experimental/tx_status.rs
@@ -1,3 +1,34 @@
+//! Queries the status of a transaction.
+//!
+//! ## Example
+//! Returns the final transaction result for
+//! <https://explorer.near.org/transactions/B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq>
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_primitives::views;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//! let tx_hash = "B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq".parse()?;
+//!
+//! let request = methods::EXPERIMENTAL_tx_status::RpcTransactionStatusRequest {
+//!     transaction_info: methods::EXPERIMENTAL_tx_status::TransactionInfo::TransactionId {
+//!         hash: tx_hash,
+//!         account_id: "itranscend.near".parse()?,
+//!    }
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     views::FinalExecutionOutcomeWithReceiptView { .. }
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::transactions::RpcTransactionError;

--- a/src/methods/experimental/tx_status.rs
+++ b/src/methods/experimental/tx_status.rs
@@ -1,6 +1,7 @@
 //! Queries the status of a transaction.
 //!
 //! ## Example
+//!
 //! Returns the final transaction result for
 //! <https://explorer.near.org/transactions/B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq>
 //!


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the experimental `tx_status` RPC method, including an easy-to-understand example.