### PR TITLE
chore(docs): document the `EXPERIMENTAL_check_tx` RPC method

### DIFF
--- a/src/methods/experimental/check_tx.rs
+++ b/src/methods/experimental/check_tx.rs
@@ -1,3 +1,76 @@
+//! Checks a transaction on the network
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_jsonrpc_primitives::types::{query::QueryResponseKind, transactions};
+//! use near_primitives::types::{AccountId, BlockReference};
+//! use near_primitives::transaction::{Action, Transaction, FunctionCallAction};
+//! use near_crypto::SecretKey;
+//! use core::str::FromStr;
+//! use serde_json::json;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
+//!
+//! let signer_account_id = "fido.testnet".parse::<AccountId>()?;
+//! let signer_secret_key = SecretKey::from_str("ed25519:12dhevYshfiRqFSu8DSfxA27pTkmGRv6C5qQWTJYTcBEoB7MSTyidghi5NWXzWqrxCKgxVx97bpXPYQxYN5dieU")?;    // Replace secret_key with valid signer_secret_key
+//!
+//! let signer = near_crypto::InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
+//! println!("{}, {}", signer.account_id, signer.public_key);
+//!
+//! let access_key_query_response = client
+//!     .call(methods::query::RpcQueryRequest {
+//!         block_reference: BlockReference::latest(),
+//!         request: near_primitives::views::QueryRequest::ViewAccessKey {
+//!             account_id: signer.account_id.clone(),
+//!             public_key: signer.public_key.clone(),
+//!         },
+//!     })
+//!     .await?;
+//!
+//! let current_nonce = match access_key_query_response.kind {
+//!     QueryResponseKind::AccessKey(access_key) => access_key.nonce,
+//!     _ => Err("failed to extract current nonce")?,
+//!  };
+//!
+//! let other_account = "rpc_docs.testnet".parse::<AccountId>()?;
+//! let rating = "4.7".parse::<f32>()?;
+//!
+//! let transaction = Transaction {
+//!     signer_id: signer.account_id.clone(),
+//!     public_key: signer.public_key.clone(),
+//!     nonce: current_nonce + 1,
+//!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
+//!     block_hash: access_key_query_response.block_hash,
+//!     actions: vec![Action::FunctionCall(FunctionCallAction {
+//!         method_name: "rate".to_string(),
+//!         args: json!({
+//!             "account_id": other_account,
+//!             "rating": rating,
+//!         })
+//!         .to_string()
+//!         .into_bytes(),
+//!         gas: 100_000_000_000_000, // 100 TeraGas
+//!         deposit: 0,
+//!     })],
+//! };
+//!
+//! let request = methods::EXPERIMENTAL_check_tx::RpcCheckTxRequest {
+//!     signed_transaction: transaction.sign(&signer)
+//! };
+//!
+//! let response = client.call(request).await;
+//!
+//! assert!(matches!(
+//!     response,
+//!     Ok(methods::EXPERIMENTAL_check_tx::RpcBroadcastTxSyncResponse { .. })
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::transactions::{

--- a/src/methods/experimental/check_tx.rs
+++ b/src/methods/experimental/check_tx.rs
@@ -1,4 +1,8 @@
-//! Checks a transaction on the network
+//! Checks a transaction on the network.
+//!
+//! This code sample doesn't make any request to the RPC node. It's been truncated for brevity sake.
+//!
+//! An example detailing how to construct a complete request can be found at [`contract_change_method`](https://github.com/near/near-jsonrpc-client-rs/blob/master/examples/contract_change_method.rs).
 //!
 //! ## Example
 //!
@@ -19,22 +23,6 @@
 //! let signer_secret_key = SecretKey::from_str("ed25519:12dhevYshfiRqFSu8DSfxA27pTkmGRv6C5qQWTJYTcBEoB7MSTyidghi5NWXzWqrxCKgxVx97bpXPYQxYN5dieU")?;    // Replace secret_key with valid signer_secret_key
 //!
 //! let signer = near_crypto::InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
-//! println!("{}, {}", signer.account_id, signer.public_key);
-//!
-//! let access_key_query_response = client
-//!     .call(methods::query::RpcQueryRequest {
-//!         block_reference: BlockReference::latest(),
-//!         request: near_primitives::views::QueryRequest::ViewAccessKey {
-//!             account_id: signer.account_id.clone(),
-//!             public_key: signer.public_key.clone(),
-//!         },
-//!     })
-//!     .await?;
-//!
-//! let current_nonce = match access_key_query_response.kind {
-//!     QueryResponseKind::AccessKey(access_key) => access_key.nonce,
-//!     _ => Err("failed to extract current nonce")?,
-//!  };
 //!
 //! let other_account = "rpc_docs.testnet".parse::<AccountId>()?;
 //! let rating = "4.7".parse::<f32>()?;
@@ -42,9 +30,9 @@
 //! let transaction = Transaction {
 //!     signer_id: signer.account_id.clone(),
 //!     public_key: signer.public_key.clone(),
-//!     nonce: current_nonce + 1,
+//!     nonce: 904565 + 1,
 //!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
-//!     block_hash: access_key_query_response.block_hash,
+//!     block_hash: "AUDcb2iNUbsmCsmYGfGuKzyXKimiNcCZjBKTVsbZGnoH".parse()?,
 //!     actions: vec![Action::FunctionCall(FunctionCallAction {
 //!         method_name: "rate".to_string(),
 //!         args: json!({
@@ -61,13 +49,6 @@
 //! let request = methods::EXPERIMENTAL_check_tx::RpcCheckTxRequest {
 //!     signed_transaction: transaction.sign(&signer)
 //! };
-//!
-//! let response = client.call(request).await;
-//!
-//! assert!(matches!(
-//!     response,
-//!     Ok(methods::EXPERIMENTAL_check_tx::RpcBroadcastTxSyncResponse { .. })
-//! ));
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `EXPERIMENTAL_check_tx` RPC method, including an easy-to-understand example.