### PR TITLE
fix: `gas_price` RPC method serialization

### DIFF
--- a/src/methods/gas_price.rs
+++ b/src/methods/gas_price.rs
@@ -21,7 +21,7 @@ impl RpcMethod for RpcGasPriceRequest {
     }
 
     fn params(&self) -> Result<serde_json::Value, io::Error> {
-        Ok(json!([self]))
+        Ok(json!([self.block_id]))
     }
 }
 


### PR DESCRIPTION
Fixes serialization with the `gas_price` RPC method.

Related upstream fix: https://github.com/near/nearcore/pull/6532