### PR TITLE
chore(docs): document the `sandbox_fast_forward` RPC method

### DIFF
--- a/src/methods/sandbox/fast_forward.rs
+++ b/src/methods/sandbox/fast_forward.rs
@@ -1,3 +1,29 @@
+//! Fast forwards a sandboxed node by a specific height.
+//!
+//! Fas forwarding allows one to skip to some point in the future and observe actions.
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("http://localhost:3030");
+//!
+//! let request = methods::sandbox_fast_forward::RpcSandboxFastForwardRequest {
+//!     delta_height: 12,
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     methods::sandbox_fast_forward::RpcSandboxFastForwardResponse { .. }
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::sandbox::{


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `sandbox_fast_forward` RPC method, including an easy-to-understand example.