### PR TITLE
chore(docs): document the `validators` RPC method

### DIFF
--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -5,6 +5,7 @@
 //! ## Examples
 //!
 //! - Get the validators for a specified epoch.
+//!
 //!     ```
 //!     use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::types::{EpochReference, EpochId, BlockReference, Finality};
@@ -35,54 +36,8 @@
 //!     # }
 //!     ```
 //!
-//! - Get the validators for a given block
-//!     - By hash
-//!         ```
-//!         use near_jsonrpc_client::{methods, JsonRpcClient};
-//!         use near_primitives::types::{EpochReference, BlockId};
-//!   
-//!         # #[tokio::main]
-//!         # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!         let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
-//!   
-//!         let request = methods::validators::RpcValidatorRequest {
-//!             epoch_reference: EpochReference::BlockId(BlockId::Hash("F5a8etpwPegFXctaZ4GoCB23StRhhK5iWNhLo6t4aPxb".parse()?))
-//!         };
-//!   
-//!         let response = client.call(request).await?;
-//!   
-//!         assert!(matches!(
-//!             response,
-//!             methods::validators::RpcValidatorResponse { .. }
-//!         ));
-//!         # Ok(())
-//!         # }
-//!         ```
-//!
-//!     - By height
-//!         ```
-//!         use near_jsonrpc_client::{methods, JsonRpcClient};
-//!         use near_primitives::types::{EpochReference, BlockId};
-//!   
-//!         # #[tokio::main]
-//!         # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!         let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
-//!   
-//!         let request = methods::validators::RpcValidatorRequest {
-//!             epoch_reference: EpochReference::BlockId(BlockId::Height(61262499))
-//!         };
-//!   
-//!         let response = client.call(request).await?;
-//!   
-//!         assert!(matches!(
-//!             response,
-//!             methods::validators::RpcValidatorResponse { .. }
-//!         ));
-//!         # Ok(())
-//!         # }
-//!         ```
-//!
 //! - Get the validators for the latest block
+//!
 //!     ```
 //!     use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::types::{EpochReference, EpochId, BlockId};

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -1,3 +1,109 @@
+//! Queries active validators on the network.
+//!
+//! Returns details and the state of validation on the blockchain.
+//!
+//! ## Examples
+//!
+//! - Get the validators for a specified epoch.
+//!     ```
+//!     use near_jsonrpc_client::{methods, JsonRpcClient};
+//!     use near_primitives::types::{EpochReference, EpochId, BlockReference, Finality};
+//!   
+//!     # #[tokio::main]
+//!     # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!   
+//!     let block_request = methods::block::RpcBlockRequest {
+//!         block_reference: BlockReference::Finality(Finality::Final),
+//!     };
+//!     let block_response = client.call(block_request).await?;
+//!     let epoch_hash = block_response.header.epoch_id;
+//!   
+//!     let request = methods::validators::RpcValidatorRequest {
+//!         epoch_reference: EpochReference::EpochId(EpochId {
+//!             0: epoch_hash,
+//!         })
+//!     };
+//!   
+//!     let response = client.call(request).await?;
+//!   
+//!     assert!(matches!(
+//!         response,
+//!         methods::validators::RpcValidatorResponse { .. }
+//!     ));
+//!     # Ok(())
+//!     # }
+//!     ```
+//!
+//! - Get the validators for a given block
+//!     - By hash
+//!         ```
+//!         use near_jsonrpc_client::{methods, JsonRpcClient};
+//!         use near_primitives::types::{EpochReference, BlockId};
+//!   
+//!         # #[tokio::main]
+//!         # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!         let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//!   
+//!         let request = methods::validators::RpcValidatorRequest {
+//!             epoch_reference: EpochReference::BlockId(BlockId::Hash("F5a8etpwPegFXctaZ4GoCB23StRhhK5iWNhLo6t4aPxb".parse()?))
+//!         };
+//!   
+//!         let response = client.call(request).await?;
+//!   
+//!         assert!(matches!(
+//!             response,
+//!             methods::validators::RpcValidatorResponse { .. }
+//!         ));
+//!         # Ok(())
+//!         # }
+//!         ```
+//!
+//!     - By height
+//!         ```
+//!         use near_jsonrpc_client::{methods, JsonRpcClient};
+//!         use near_primitives::types::{EpochReference, BlockId};
+//!   
+//!         # #[tokio::main]
+//!         # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!         let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//!   
+//!         let request = methods::validators::RpcValidatorRequest {
+//!             epoch_reference: EpochReference::BlockId(BlockId::Height(61262499))
+//!         };
+//!   
+//!         let response = client.call(request).await?;
+//!   
+//!         assert!(matches!(
+//!             response,
+//!             methods::validators::RpcValidatorResponse { .. }
+//!         ));
+//!         # Ok(())
+//!         # }
+//!         ```
+//!
+//! - Get the validators for the latest block
+//!     ```
+//!     use near_jsonrpc_client::{methods, JsonRpcClient};
+//!     use near_primitives::types::{EpochReference, EpochId, BlockId};
+//!   
+//!     # #[tokio::main]
+//!     # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!   
+//!     let request = methods::validators::RpcValidatorRequest {
+//!         epoch_reference: EpochReference::Latest
+//!     };
+//!   
+//!     let response = client.call(request).await?;
+//!   
+//!     assert!(matches!(
+//!         response,
+//!         methods::validators::RpcValidatorResponse { .. }
+//!     ));
+//!     # Ok(())
+//!     # }
+//!     ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::validator::{RpcValidatorError, RpcValidatorRequest};

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -6,59 +6,59 @@
 //!
 //! - Get the validators for a specified epoch.
 //!
-//!     ```
-//!     use near_jsonrpc_client::{methods, JsonRpcClient};
-//!     use near_primitives::types::{EpochReference, EpochId, BlockReference, Finality};
-//!   
-//!     # #[tokio::main]
-//!     # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
-//!   
-//!     let block_request = methods::block::RpcBlockRequest {
-//!         block_reference: BlockReference::Finality(Finality::Final),
-//!     };
-//!     let block_response = client.call(block_request).await?;
-//!     let epoch_hash = block_response.header.epoch_id;
-//!   
-//!     let request = methods::validators::RpcValidatorRequest {
-//!         epoch_reference: EpochReference::EpochId(EpochId {
-//!             0: epoch_hash,
-//!         })
-//!     };
-//!   
-//!     let response = client.call(request).await?;
-//!   
-//!     assert!(matches!(
-//!         response,
-//!         methods::validators::RpcValidatorResponse { .. }
-//!     ));
-//!     # Ok(())
-//!     # }
-//!     ```
+//!   ```
+//!   use near_jsonrpc_client::{methods, JsonRpcClient};
+//!   use near_primitives::types::{EpochReference, EpochId, BlockReference, Finality};
 //!
-//! - Get the validators for the latest block
+//!   # #[tokio::main]
+//!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!   let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
 //!
-//!     ```
-//!     use near_jsonrpc_client::{methods, JsonRpcClient};
-//!     use near_primitives::types::{EpochReference, EpochId, BlockId};
-//!   
-//!     # #[tokio::main]
-//!     # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
-//!   
-//!     let request = methods::validators::RpcValidatorRequest {
-//!         epoch_reference: EpochReference::Latest
-//!     };
-//!   
-//!     let response = client.call(request).await?;
-//!   
-//!     assert!(matches!(
-//!         response,
-//!         methods::validators::RpcValidatorResponse { .. }
-//!     ));
-//!     # Ok(())
-//!     # }
-//!     ```
+//!   let block_request = methods::block::RpcBlockRequest {
+//!       block_reference: BlockReference::Finality(Finality::Final),
+//!   };
+//!   let block_response = client.call(block_request).await?;
+//!   let epoch_hash = block_response.header.epoch_id;
+//!
+//!   let request = methods::validators::RpcValidatorRequest {
+//!       epoch_reference: EpochReference::EpochId(EpochId {
+//!           0: epoch_hash,
+//!       })
+//!   };
+//!
+//!   let response = client.call(request).await?;
+//!
+//!   assert!(matches!(
+//!       response,
+//!       methods::validators::RpcValidatorResponse { .. }
+//!   ));
+//!   # Ok(())
+//!   # }
+//!   ```
+//!
+//! - Get the validators for the latest block.
+//!
+//!   ```
+//!   use near_jsonrpc_client::{methods, JsonRpcClient};
+//!   use near_primitives::types::{EpochReference, EpochId, BlockId};
+//!
+//!   # #[tokio::main]
+//!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!   let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!
+//!   let request = methods::validators::RpcValidatorRequest {
+//!       epoch_reference: EpochReference::Latest
+//!   };
+//!
+//!   let response = client.call(request).await?;
+//!
+//!   assert!(matches!(
+//!       response,
+//!       methods::validators::RpcValidatorResponse { .. }
+//!   ));
+//!   # Ok(())
+//!   # }
+//!   ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::validator::{RpcValidatorError, RpcValidatorRequest};

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -12,17 +12,11 @@
 //!
 //!   # #[tokio::main]
 //!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!   let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
-//!
-//!   let block_request = methods::block::RpcBlockRequest {
-//!       block_reference: BlockReference::Finality(Finality::Final),
-//!   };
-//!   let block_response = client.call(block_request).await?;
-//!   let epoch_hash = block_response.header.epoch_id;
+//!   let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //!   let request = methods::validators::RpcValidatorRequest {
 //!       epoch_reference: EpochReference::EpochId(EpochId {
-//!           0: epoch_hash,
+//!           0: "9xrjdZmgjoVkjVE3ui7tY37x9Mkw5wH385qNXE6cho7T".parse()?,
 //!       })
 //!   };
 //!
@@ -44,7 +38,7 @@
 //!
 //!   # #[tokio::main]
 //!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!   let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+//!   let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //!   let request = methods::validators::RpcValidatorRequest {
 //!       epoch_reference: EpochReference::Latest


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `validators` RPC method, including easy-to-understand examples.