### PR TITLE
chore(docs): document the `light_client_proof` RPC method

### DIFF
--- a/src/methods/light_client_proof.rs
+++ b/src/methods/light_client_proof.rs
@@ -1,4 +1,4 @@
-//! Verifies whether a transaction happened on chain.
+//! Returns the proofs for a transaction execution.
 //!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
@@ -6,14 +6,14 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = JsonRpcClient::connect("");
+//! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //! let request = methods::light_client_proof::RpcLightClientExecutionProofRequest {
 //!     id: TransactionOrReceiptId::Transaction {
-//!             transaction_hash: "".parse()?,
-//!             sender_id: "".parse()?,
-//!         },
-//!     light_client_head: "".parse()?,
+//!         transaction_hash: "47sXP4jKXCMpkUS6kcxsfNU7tqysYr5fxWFdEXQkZh6z".parse()?,
+//!         sender_id: "aurora.pool.near".parse()?,
+//!     },
+//!     light_client_head: "ANm3jm5wq1Z4rJv6tXWyiDtC3wYKpXVHY4iq6bE1te7B".parse()?,
 //! };
 //!
 //! let response = client.call(request).await?;

--- a/src/methods/light_client_proof.rs
+++ b/src/methods/light_client_proof.rs
@@ -1,3 +1,30 @@
+//! Verifies whether a transaction happened on chain.
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_primitives::types::TransactionOrReceiptId;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("");
+//!
+//! let request = methods::light_client_proof::RpcLightClientExecutionProofRequest {
+//!     id: TransactionOrReceiptId::Transaction {
+//!             transaction_hash: "".parse()?,
+//!             sender_id: "".parse()?,
+//!         },
+//!     light_client_head: "".parse()?,
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     methods::light_client_proof::RpcLightClientExecutionProofResponse { .. }
+//! ));
+//! Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::light_client::{


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `light_client_proof` RPC method, including an easy-to-understand example.