### PR TITLE
chore(docs): document the `next_light_client_block` RPC method

### DIFF
--- a/src/methods/next_light_client_block.rs
+++ b/src/methods/next_light_client_block.rs
@@ -1,3 +1,27 @@
+//! Returns the next light client block
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("");
+//!
+//! let request = methods::next_light_client_block::RpcLightClientNextBlockRequest {
+//!     last_block_hash: "6Qq9hYG7vQhnje4iC1hfbyhh9vNQoNem7j8Dxi7EVSdN".parse()?,
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     Some(methods::next_light_client_block::LightClientBlockView { .. })
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::light_client::{

--- a/src/methods/next_light_client_block.rs
+++ b/src/methods/next_light_client_block.rs
@@ -7,10 +7,10 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = JsonRpcClient::connect("");
+//! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //! let request = methods::next_light_client_block::RpcLightClientNextBlockRequest {
-//!     last_block_hash: "6Qq9hYG7vQhnje4iC1hfbyhh9vNQoNem7j8Dxi7EVSdN".parse()?,
+//!     last_block_hash: "ANm3jm5wq1Z4rJv6tXWyiDtC3wYKpXVHY4iq6bE1te7B".parse()?,
 //! };
 //!
 //! let response = client.call(request).await?;

--- a/src/methods/next_light_client_block.rs
+++ b/src/methods/next_light_client_block.rs
@@ -1,4 +1,4 @@
-//! Returns the next light client block
+//! Returns the next light client block.
 //!
 //! ## Example
 //!


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `next_light_client_block` RPC method, including an easy-to-understand example.