### PR TITLE
chore(docs): document the `broadcast_tx_async` RPC method

### DIFF
--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -1,3 +1,106 @@
+//! Sends asynchronous transactions.
+//! 
+//! Sends a signed transaction to the RPC and returns the transaction hash.
+//!
+//! ## Example
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_jsonrpc_primitives::types::{query::QueryResponseKind, transactions};
+//! use near_primitives::types::{AccountId, BlockReference};
+//! use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
+//! use near_crypto::SecretKey;
+//! use core::str::FromStr;
+//! use serde_json::json;
+//! use tokio::time;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
+//!
+//! let signer_account_id = "fido.testnet".parse::<AccountId>()?;
+//! let signer_secret_key = SecretKey::from_str("ed25519:12dhevYshfiRqFSu8DSfxA27pTkmGRv6C5qQWTJYTcBEoB7MSTyidghi5NWXzWqrxCKgxVx97bpXPYQxYN5dieU")?;
+//!
+//! let signer = near_crypto::InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
+//!
+//! let access_key_query_response = client
+//!     .call(methods::query::RpcQueryRequest {
+//!         block_reference: BlockReference::latest(),
+//!         request: near_primitives::views::QueryRequest::ViewAccessKey {
+//!             account_id: signer.account_id.clone(),
+//!             public_key: signer.public_key.clone(),
+//!         },
+//!     })
+//!     .await?;
+//!
+//! let current_nonce = match access_key_query_response.kind {
+//!     QueryResponseKind::AccessKey(access_key) => access_key.nonce,
+//!     _ => Err("failed to extract current nonce")?,
+//!  };
+//!     
+//! let other_account = "rpc_docs.testnet".parse::<AccountId>()?;
+//! let rating = "4.5".parse::<f32>()?;
+//!     
+//! let transaction = Transaction {
+//!     signer_id: signer.account_id.clone(),
+//!     public_key: signer.public_key.clone(),
+//!     nonce: current_nonce + 1,
+//!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
+//!     block_hash: access_key_query_response.block_hash,
+//!     actions: vec![Action::FunctionCall(FunctionCallAction {
+//!         method_name: "rate".to_string(),
+//!         args: json!({
+//!             "account_id": other_account,
+//!             "rating": rating,
+//!         })
+//!         .to_string()
+//!         .into_bytes(),
+//!         gas: 100_000_000_000_000, // 100 TeraGas
+//!         deposit: 0,
+//!     })],
+//! };
+//!
+//! let request = methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
+//!     signed_transaction: transaction.sign(&signer)
+//! };
+//!
+//! let sent_at = time::Instant::now();
+//! let tx_hash = client.call(request).await?;
+//!
+//! loop {
+//!     let response = client
+//!         .call(methods::tx::RpcTransactionStatusRequest {
+//!             transaction_info: transactions::TransactionInfo::TransactionId {
+//!                 hash: tx_hash,
+//!                 account_id: signer.account_id.clone(),
+//!             },
+//!         })
+//!     .await;
+//!     let received_at = time::Instant::now();
+//!     let delta = (received_at - sent_at).as_secs();
+//!
+//!     if delta > 60 {
+//!         Err("time limit exceeded for the transaction to be recognized")?;
+//!     }
+//!
+//!     match response {
+//!         Err(err) => match err.handler_error()? {
+//!             methods::tx::RpcTransactionError::UnknownTransaction { .. } => {
+//!                 time::sleep(time::Duration::from_secs(2)).await;
+//!                 continue;
+//!             }
+//!             err => Err(err)?,
+//!         },
+//!         Ok(response) => {
+//!             println!("response gotten after: {}s", delta);
+//!             println!("response: {:#?}", response);
+//!             break;
+//!         }
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_primitives::transaction::SignedTransaction;

--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -1,8 +1,12 @@
 //! Sends asynchronous transactions.
 //!
-//! Sends a signed transaction to the RPC and returns the transaction hash.
-//!
 //! ## Example
+//!
+//! Constructs a signed transaction to be sent to an RPC node. It returns the transaction hash if successful.
+//!
+//! This code sample doesn't make any requests to the RPC node. It only shows how to construct the request. It's been truncated for brevity sake.
+//!
+//! A full example on how to use `broadcast_tx_async` method can be found at [`contract_change_method`](https://github.com/near/near-jsonrpc-client-rs/blob/master/examples/contract_change_method.rs).
 //!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};

--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -1,5 +1,5 @@
 //! Sends asynchronous transactions.
-//! 
+//!
 //! Sends a signed transaction to the RPC and returns the transaction hash.
 //!
 //! ## Example

--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -6,13 +6,11 @@
 //!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
-//! use near_jsonrpc_primitives::types::{query::QueryResponseKind, transactions};
-//! use near_primitives::types::{AccountId, BlockReference};
+//! use near_primitives::types::{AccountId};
 //! use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
 //! use near_crypto::SecretKey;
 //! use core::str::FromStr;
 //! use serde_json::json;
-//! use tokio::time;
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,30 +21,15 @@
 //!
 //! let signer = near_crypto::InMemorySigner::from_secret_key(signer_account_id, signer_secret_key);
 //!
-//! let access_key_query_response = client
-//!     .call(methods::query::RpcQueryRequest {
-//!         block_reference: BlockReference::latest(),
-//!         request: near_primitives::views::QueryRequest::ViewAccessKey {
-//!             account_id: signer.account_id.clone(),
-//!             public_key: signer.public_key.clone(),
-//!         },
-//!     })
-//!     .await?;
-//!
-//! let current_nonce = match access_key_query_response.kind {
-//!     QueryResponseKind::AccessKey(access_key) => access_key.nonce,
-//!     _ => Err("failed to extract current nonce")?,
-//!  };
-//!     
 //! let other_account = "rpc_docs.testnet".parse::<AccountId>()?;
 //! let rating = "4.5".parse::<f32>()?;
-//!     
+//!
 //! let transaction = Transaction {
 //!     signer_id: signer.account_id.clone(),
 //!     public_key: signer.public_key.clone(),
-//!     nonce: current_nonce + 1,
+//!     nonce: 10223934 + 1,
 //!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
-//!     block_hash: access_key_query_response.block_hash,
+//!     block_hash: "AUDcb2iNUbsmCsmYGfGuKzyXKimiNcCZjBKTVsbZGnoH".parse()?,
 //!     actions: vec![Action::FunctionCall(FunctionCallAction {
 //!         method_name: "rate".to_string(),
 //!         args: json!({
@@ -63,41 +46,6 @@
 //! let request = methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
 //!     signed_transaction: transaction.sign(&signer)
 //! };
-//!
-//! let sent_at = time::Instant::now();
-//! let tx_hash = client.call(request).await?;
-//!
-//! loop {
-//!     let response = client
-//!         .call(methods::tx::RpcTransactionStatusRequest {
-//!             transaction_info: transactions::TransactionInfo::TransactionId {
-//!                 hash: tx_hash,
-//!                 account_id: signer.account_id.clone(),
-//!             },
-//!         })
-//!     .await;
-//!     let received_at = time::Instant::now();
-//!     let delta = (received_at - sent_at).as_secs();
-//!
-//!     if delta > 60 {
-//!         Err("time limit exceeded for the transaction to be recognized")?;
-//!     }
-//!
-//!     match response {
-//!         Err(err) => match err.handler_error()? {
-//!             methods::tx::RpcTransactionError::UnknownTransaction { .. } => {
-//!                 time::sleep(time::Duration::from_secs(2)).await;
-//!                 continue;
-//!             }
-//!             err => Err(err)?,
-//!         },
-//!         Ok(response) => {
-//!             println!("response gotten after: {}s", delta);
-//!             println!("response: {:#?}", response);
-//!             break;
-//!         }
-//!     }
-//! }
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `broadcast_tx_async` RPC method, including an easy-to-understand example.