### PR TITLE
chore(docs): document the `sandbox_patch_state` RPC method

### DIFF
--- a/src/methods/sandbox/patch_state.rs
+++ b/src/methods/sandbox/patch_state.rs
@@ -1,7 +1,7 @@
 //! Patch account, access keys, contract code, or contract state.
 //!
-//! Only additions and mutations are supported. No deletions. 
-//! 
+//! Only additions and mutations are supported. No deletions.
+//!
 //! Account, access keys, contract code, and contract states have different formats. See the example and docs for details about their format.
 //!
 //! ## Examples

--- a/src/methods/sandbox/patch_state.rs
+++ b/src/methods/sandbox/patch_state.rs
@@ -1,3 +1,38 @@
+//! Patch account, access keys, contract code, or contract state.
+//!
+//! Only additions and mutations are supported. No deletions. 
+//! 
+//! Account, access keys, contract code, and contract states have different formats. See the example and docs for details about their format.
+//!
+//! ## Examples
+//!
+//! ```
+//! use near_jsonrpc_client::{methods, JsonRpcClient};
+//! use near_primitives::{state_record::StateRecord, account, types::{AccountId, StorageUsage}};
+//! use near_primitives::{account::AccountVersion, hash::CryptoHash};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = JsonRpcClient::connect("http://localhost:3030");
+//!
+//! let request = methods::sandbox_patch_state::RpcSandboxPatchStateRequest {
+//!     records: vec![
+//!         StateRecord::Account {
+//!             account_id: "fido.testnet".parse::<AccountId>()?,
+//!             account: account::Account::new(179, 0, CryptoHash::default(), 264)
+//!          }
+//!     ],
+//! };
+//!
+//! let response = client.call(request).await?;
+//!
+//! assert!(matches!(
+//!     response,
+//!     methods::sandbox_patch_state::RpcSandboxPatchStateResponse { .. }
+//! ));
+//! # Ok(())
+//! # }
+//! ```
 use super::*;
 
 pub use near_jsonrpc_primitives::types::sandbox::{

--- a/src/methods/sandbox/patch_state.rs
+++ b/src/methods/sandbox/patch_state.rs
@@ -8,8 +8,7 @@
 //!
 //! ```
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
-//! use near_primitives::{state_record::StateRecord, account, types::{AccountId, StorageUsage}};
-//! use near_primitives::{account::AccountVersion, hash::CryptoHash};
+//! use near_primitives::{state_record::StateRecord, account, types::AccountId, hash::CryptoHash};
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Tracking issue: <https://github.com/near/near-jsonrpc-client-rs/issues/51>

Documented the `sandbox_patch_state` RPC method, including an easy-to-understand example.