### PR TITLE
fix: patch query response deserialization, add tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ thiserror = "1.0.28"
 serde_json = "1.0.66"
 lazy_static = "1.4.0"
 
+near-crypto = "0.12.0"
 near-primitives = "0.12.0"
 near-chain-configs = "0.12.0"
 near-jsonrpc-primitives = "0.12.0"
 
 [dev-dependencies]
-near-crypto = "0.12.0"
 tokio = { version = "1.1", features = ["rt", "macros"] }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,13 +257,15 @@ impl JsonRpcClient {
         })?;
 
         if let Message::Response(response) = response_message {
-            return methods::RpcHandlerResponse::parse(response.result?).map_err(|err| {
-                JsonRpcError::TransportError(RpcTransportError::RecvError(
-                    JsonRpcTransportRecvError::ResponseParseError(
-                        JsonRpcTransportHandlerResponseError::ResultParseError(err),
-                    ),
-                ))
-            });
+            return M::parse_handler_response(response.result)
+                .map_err(|err| {
+                    JsonRpcError::TransportError(RpcTransportError::RecvError(
+                        JsonRpcTransportRecvError::ResponseParseError(
+                            JsonRpcTransportHandlerResponseError::ResultParseError(err),
+                        ),
+                    ))
+                })?
+                .map_err(Into::into);
         }
         Err(JsonRpcError::TransportError(RpcTransportError::RecvError(
             JsonRpcTransportRecvError::UnexpectedServerResponse(response_message),

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -19,7 +19,18 @@ where
     fn method_name(&self) -> &str;
 
     fn params(&self) -> Result<serde_json::Value, io::Error>;
+
+    fn parse_handler_response(
+        response: Result<serde_json::Value, near_jsonrpc_primitives::errors::RpcError>,
+    ) -> Result<MaybeHandlerResponse<Self::Response>, serde_json::Error> {
+        match response {
+            Ok(value) => Self::Response::parse(value).map(Ok),
+            Err(rpc_error) => Ok(Err(rpc_error)),
+        }
+    }
 }
+
+pub type MaybeHandlerResponse<T> = Result<T, near_jsonrpc_primitives::errors::RpcError>;
 
 impl<T> private::Sealed for &T where T: private::Sealed {}
 impl<T> RpcMethod for &T

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -6,6 +6,8 @@ impl RpcHandlerResponse for RpcQueryResponse {}
 
 impl RpcHandlerError for RpcQueryError {}
 
+impl private::Sealed for RpcQueryRequest {}
+
 impl RpcMethod for RpcQueryRequest {
     type Response = RpcQueryResponse;
     type Error = RpcQueryError;
@@ -17,6 +19,143 @@ impl RpcMethod for RpcQueryRequest {
     fn params(&self) -> Result<serde_json::Value, io::Error> {
         Ok(json!(self))
     }
+
+    fn parse_handler_response(
+        response: Result<serde_json::Value, near_jsonrpc_primitives::errors::RpcError>,
+    ) -> Result<MaybeHandlerResponse<Self::Response>, serde_json::Error> {
+        match response {
+            Ok(value) => match serde_json::from_value::<QueryResponse>(value)? {
+                QueryResponse::HandlerResponse(r) => Ok(Ok(r)),
+                QueryResponse::HandlerError(LegacyQueryError {
+                    error,
+                    block_height,
+                    block_hash,
+                }) => {
+                    let mut err_parts = error.split(" ");
+                    let query_response = if let (
+                        Some("access"),
+                        Some("key"),
+                        Some(pk),
+                        Some("does"),
+                        Some("not"),
+                        Some("exist"),
+                        Some("while"),
+                        Some("viewing"),
+                        None,
+                    ) = (
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                        err_parts.next(),
+                    ) {
+                        let public_key = pk
+                            .parse::<near_crypto::PublicKey>()
+                            .map_err(serde::de::Error::custom)?;
+                        RpcQueryError::UnknownAccessKey {
+                            public_key,
+                            block_height,
+                            block_hash,
+                        }
+                    } else {
+                        RpcQueryError::ContractExecutionError {
+                            vm_error: error,
+                            block_height,
+                            block_hash,
+                        }
+                    };
+
+                    Ok(Err(query_response.into()))
+                }
+            },
+            Err(rpc_error) => Ok(Err(rpc_error)),
+        }
+    }
 }
 
-impl private::Sealed for RpcQueryRequest {}
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum QueryResponse {
+    HandlerResponse(RpcQueryResponse),
+    HandlerError(LegacyQueryError),
+}
+
+#[derive(serde::Deserialize)]
+struct LegacyQueryError {
+    error: String,
+    block_height: near_primitives::types::BlockHeight,
+    block_hash: near_primitives::hash::CryptoHash,
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, crate::*};
+
+    #[tokio::test]
+    async fn test_unknown_access_key() -> Result<(), Box<dyn std::error::Error>> {
+        let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
+
+        let request = RpcQueryRequest {
+            block_reference: near_primitives::types::BlockReference::BlockId(
+                near_primitives::types::BlockId::Height(63503911),
+            ),
+            request: near_primitives::views::QueryRequest::ViewAccessKey {
+                account_id: "miraclx.testnet".parse()?,
+                public_key: "ed25519:9KnjTjL6vVoM8heHvCcTgLZ67FwFkiLsNtknFAVsVvYY".parse()?,
+            },
+        };
+
+        let response = client.call(request).await.unwrap_err();
+
+        let err = response.handler_error()?;
+        assert!(matches!(
+            err,
+            RpcQueryError::UnknownAccessKey {
+                ref public_key,
+                block_height: 63503911,
+                ..
+            } if public_key.to_string() == "ed25519:9KnjTjL6vVoM8heHvCcTgLZ67FwFkiLsNtknFAVsVvYY"
+        ),);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_contract_execution_error() -> Result<(), Box<dyn std::error::Error>> {
+        let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
+
+        let request = RpcQueryRequest {
+            block_reference: near_primitives::types::BlockReference::BlockId(
+                near_primitives::types::BlockId::Height(63503911),
+            ),
+            request: near_primitives::views::QueryRequest::CallFunction {
+                #[allow(deprecated)]
+                account_id: "miraclx.testnet".parse()?,
+                method_name: "".to_string(),
+                args: (b"{}".to_vec()).into(),
+            },
+        };
+
+        let response = client.call(request).await.unwrap_err();
+
+        let err = response.handler_error()?;
+        assert!(
+            matches!(
+                err,
+                RpcQueryError::ContractExecutionError {
+                    ref vm_error,
+                    block_height: 63503911,
+                    ..
+                } if vm_error.contains("FunctionCallError(MethodResolveError(MethodEmptyName))")
+            ),
+            "{:?}",
+            err
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Context:
 - https://github.com/near/nearcore/issues/6384
 - https://github.com/near/near-jsonrpc-client-rs/issues/74
 - https://github.com/near/nearcore/pull/6600

This patch adds client compatibility for the legacy error format returned from the `query` RPC method. 