### PR TITLE
chore: version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-04-20
+
 - Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
 - Extracted all the RPC methods into their own modules instead of all being defined in the same `methods.rs` file. <https://github.com/near/near-jsonrpc-client-rs/pull/50>
 
@@ -33,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/near/near-jsonrpc-client-rs/releases/tag/v0.1.0>
 
-[unreleased]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/near/near-jsonrpc-client-rs/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.56.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"], optional = true }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 [![crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
 ![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.3.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.3.0)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.4.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.4.0)
 
 ## Usage
 


### PR DESCRIPTION
Scheduled release: 31-05-2022

Notable changes:

  - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
  - Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
  - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
  - Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
  - Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
  - Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
  - Extracted all the RPC methods into their own modules instead of all being defined in the same `methods.rs` file. <https://github.com/near/near-jsonrpc-client-rs/pull/50>

Aspirational:

  - Exhaustively documented the client. <https://github.com/near/near-jsonrpc-client-rs/issues/51>