### PR TITLE
fix: unserialized error compat is exclusively for `.error_struct`, not `.data`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -111,7 +111,7 @@ impl<E: super::methods::RpcHandlerError> From<RpcError> for JsonRpcError<E> {
             None => {}
         }
         if let Some(ref raw_err_data) = err.data {
-            match E::parse_raw_error(raw_err_data.clone()) {
+            match E::parse_legacy_error(raw_err_data.clone()) {
                 Some(Ok(handler_error)) => {
                     return JsonRpcError::ServerError(JsonRpcServerError::HandlerError(
                         handler_error,

--- a/src/methods/block.rs
+++ b/src/methods/block.rs
@@ -72,7 +72,7 @@ pub type RpcBlockResponse = near_primitives::views::BlockView;
 impl RpcHandlerResponse for RpcBlockResponse {}
 
 impl RpcHandlerError for RpcBlockError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }

--- a/src/methods/chunk.rs
+++ b/src/methods/chunk.rs
@@ -99,7 +99,7 @@ pub type RpcChunkResponse = near_primitives::views::ChunkView;
 impl RpcHandlerResponse for RpcChunkResponse {}
 
 impl RpcHandlerError for RpcChunkError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }

--- a/src/methods/experimental/protocol_config.rs
+++ b/src/methods/experimental/protocol_config.rs
@@ -9,7 +9,7 @@ pub type RpcProtocolConfigResponse = near_chain_configs::ProtocolConfigView;
 impl RpcHandlerResponse for RpcProtocolConfigResponse {}
 
 impl RpcHandlerError for RpcProtocolConfigError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }

--- a/src/methods/gas_price.rs
+++ b/src/methods/gas_price.rs
@@ -7,7 +7,7 @@ pub type RpcGasPriceResponse = near_primitives::views::GasPriceView;
 impl RpcHandlerResponse for RpcGasPriceResponse {}
 
 impl RpcHandlerError for RpcGasPriceError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }

--- a/src/methods/light_client_proof.rs
+++ b/src/methods/light_client_proof.rs
@@ -35,7 +35,7 @@ pub use near_jsonrpc_primitives::types::light_client::{
 impl RpcHandlerResponse for RpcLightClientExecutionProofResponse {}
 
 impl RpcHandlerError for RpcLightClientProofError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -61,7 +61,7 @@ pub trait RpcHandlerError: serde::de::DeserializeOwned {
     /// This would only ever be used as a fallback if [`RpcHandlerError::parse`] fails.
     ///
     /// Defaults to `None` meaning there's no alternative deserialization available.
-    fn parse_raw_error(_error: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse_legacy_error(_error: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
         None
     }
 }
@@ -153,12 +153,16 @@ mod common {
     // their UnknownBlock variants.
     macro_rules! _parse_unknown_block {
         ($json:expr => $err_ty:ident) => {
-            if $json["name"] == "UNKNOWN_BLOCK" {
-                Some(Ok($err_ty::UnknownBlock {
-                    error_message: "".to_string(),
-                }))
-            } else {
-                None
+            match $json {
+                err => {
+                    if err["name"] == "UNKNOWN_BLOCK" {
+                        Ok($err_ty::UnknownBlock {
+                            error_message: "".to_string(),
+                        })
+                    } else {
+                        serde_json::from_value(err)
+                    }
+                }
             }
         };
     }
@@ -203,7 +207,7 @@ mod common {
 
     // broadcast_tx_commit, tx, EXPERIMENTAL_check_tx, EXPERIMENTAL_tx_status
     impl RpcHandlerError for near_jsonrpc_primitives::types::transactions::RpcTransactionError {
-        fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+        fn parse_legacy_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
             match serde_json::from_value::<near_jsonrpc_primitives::errors::ServerError>(value) {
                 Ok(near_jsonrpc_primitives::errors::ServerError::TxExecutionError(
                     near_primitives::errors::TxExecutionError::InvalidTxError(context),
@@ -219,7 +223,7 @@ mod common {
 
     // EXPERIMENTAL_changes, EXPERIMENTAL_changes_in_block
     impl RpcHandlerError for near_jsonrpc_primitives::types::changes::RpcStateChangesError {
-        fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+        fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
             parse_unknown_block!(value => Self)
         }
     }

--- a/src/methods/next_light_client_block.rs
+++ b/src/methods/next_light_client_block.rs
@@ -10,7 +10,7 @@ pub type RpcLightClientNextBlockResponse = Option<LightClientBlockView>;
 impl RpcHandlerResponse for RpcLightClientNextBlockResponse {}
 
 impl RpcHandlerError for RpcLightClientNextBlockError {
-    fn parse_raw_error(value: serde_json::Value) -> Option<Result<Self, serde_json::Error>> {
+    fn parse(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         common::parse_unknown_block!(value => Self)
     }
 }


### PR DESCRIPTION
Further context: https://github.com/near/near-jsonrpc-client-rs/pull/29

This workaround should've been applied on the `.error_struct` variant and not `.data`.