### PR TITLE
fix: rework the JsonRpcError::handler_error method

### DIFF
--- a/examples/contract_change_method.rs
+++ b/examples/contract_change_method.rs
@@ -81,12 +81,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         match response {
-            Err(err) => match err.handler_error()? {
-                methods::tx::RpcTransactionError::UnknownTransaction { .. } => {
+            Err(err) => match err.handler_error() {
+                Some(methods::tx::RpcTransactionError::UnknownTransaction { .. }) => {
                     time::sleep(time::Duration::from_secs(2)).await;
                     continue;
                 }
-                err => Err(err)?,
+                _ => Err(err)?,
             },
             Ok(response) => {
                 println!("response gotten after: {}s", delta);

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -238,13 +238,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("(!) Creating the account failed, check above for full logs");
                 break;
             }
-            Err(err) => match err.handler_error()? {
-                RpcTransactionError::TimeoutError
-                | methods::tx::RpcTransactionError::UnknownTransaction { .. } => {
+            Err(err) => match err.handler_error() {
+                Some(
+                    RpcTransactionError::TimeoutError
+                    | methods::tx::RpcTransactionError::UnknownTransaction { .. },
+                ) => {
                     time::sleep(time::Duration::from_secs(2)).await;
                     continue;
                 }
-                err => Err(err)?,
+                _ => Err(err)?,
             },
             _ => {}
         }

--- a/examples/query_block.rs
+++ b/examples/query_block.rs
@@ -73,15 +73,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             Ok(block_details) => println!("{:#?}", block_details),
             Err(err) => match err.handler_error() {
-                Ok(methods::block::RpcBlockError::UnknownBlock { .. }) => {
+                Some(methods::block::RpcBlockError::UnknownBlock { .. }) => {
                     println!("(i) Unknown block!");
                     continue;
                 }
-                Ok(err) => {
+                Some(err) => {
                     println!("(i) An error occurred `{:#?}`", err);
                     continue;
                 }
-                Err(err) => println!("(i) A non-handler error ocurred `{:#?}`", err),
+                _ => println!("(i) A non-handler error ocurred `{:#?}`", err),
             },
         };
         break;

--- a/examples/query_tx.rs
+++ b/examples/query_tx.rs
@@ -104,11 +104,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             Ok(block_details) => println!("{:#?}", block_details),
             Err(err) => match err.handler_error() {
-                Ok(err) => {
+                Some(err) => {
                     println!("(i) An error occurred `{:#?}`", err);
                     continue;
                 }
-                Err(err) => println!("(i) A non-handler error ocurred `{:#?}`", err),
+                _ => println!("(i) A non-handler error ocurred `{:#?}`", err),
             },
         };
         break;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -74,11 +74,11 @@ pub enum JsonRpcError<E> {
 }
 
 impl<E> JsonRpcError<E> {
-    pub fn handler_error(self) -> Result<E, Self> {
-        match self {
-            Self::ServerError(JsonRpcServerError::HandlerError(err)) => Ok(err),
-            err => Err(err),
+    pub fn handler_error(&self) -> Option<&E> {
+        if let Self::ServerError(JsonRpcServerError::HandlerError(err)) = self {
+            return Some(err);
         }
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,16 +477,15 @@ mod tests {
                 ]),
             ))
             .await
-            .expect_err("request must not succeed")
-            .handler_error();
+            .expect_err("request must not succeed");
 
         assert!(
             matches!(
-                tx_error,
-                Ok(methods::tx::RpcTransactionError::UnknownTransaction {
+                tx_error.handler_error(),
+                Some(methods::tx::RpcTransactionError::UnknownTransaction {
                     requested_transaction_hash
                 })
-                if requested_transaction_hash == "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8D".parse()?
+                if requested_transaction_hash.to_string() == "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8D"
             ),
             "expected an Ok(RpcTransactionError::UnknownTransaction) with matching hash, found [{:?}]",
             tx_error
@@ -541,7 +540,8 @@ mod tests {
                 ),
             )
             .await
-            .expect_err("request must not succeed")
+            .expect_err("request must not succeed");
+        let tx_error = tx_error
             .handler_error()
             .expect("expected a handler error from query request");
 

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -106,17 +106,20 @@ mod tests {
             },
         };
 
-        let response = client.call(request).await.unwrap_err();
+        let response_err = client.call(request).await.unwrap_err();
 
-        let err = response.handler_error()?;
-        assert!(matches!(
-            err,
-            RpcQueryError::UnknownAccessKey {
-                ref public_key,
-                block_height: 63503911,
-                ..
-            } if public_key.to_string() == "ed25519:9KnjTjL6vVoM8heHvCcTgLZ67FwFkiLsNtknFAVsVvYY"
-        ),);
+        assert!(
+            matches!(
+                response_err.handler_error(),
+                Some(RpcQueryError::UnknownAccessKey {
+                    ref public_key,
+                    block_height: 63503911,
+                    ..
+                }) if public_key.to_string() == "ed25519:9KnjTjL6vVoM8heHvCcTgLZ67FwFkiLsNtknFAVsVvYY"
+            ),
+            "{:#?}",
+            response_err
+        );
 
         Ok(())
     }
@@ -137,20 +140,19 @@ mod tests {
             },
         };
 
-        let response = client.call(request).await.unwrap_err();
+        let response_err = client.call(request).await.unwrap_err();
 
-        let err = response.handler_error()?;
         assert!(
             matches!(
-                err,
-                RpcQueryError::ContractExecutionError {
+                response_err.handler_error(),
+                Some(RpcQueryError::ContractExecutionError {
                     ref vm_error,
                     block_height: 63503911,
                     ..
-                } if vm_error.contains("FunctionCallError(MethodResolveError(MethodEmptyName))")
+                }) if vm_error.contains("FunctionCallError(MethodResolveError(MethodEmptyName))")
             ),
-            "{:?}",
-            err
+            "{:#?}",
+            response_err
         );
 
         Ok(())


### PR DESCRIPTION
`JsonRpcError`::`handler_error` now returns an `Option<&E>` instead of a `Result<E, JsonRpcError<E>>` easing error handling discrepancies with ownership.