### PR TITLE
chore: update nearcore dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ thiserror = "1.0.28"
 serde_json = "1.0.66"
 lazy_static = "1.4.0"
 
-near-crypto = "0.12.0"
-near-primitives = "0.12.0"
-near-chain-configs = "0.12.0"
-near-jsonrpc-primitives = "0.12.0"
+near-crypto = "0.14.0"
+near-primitives = "0.14.0"
+near-chain-configs = "0.14.0"
+near-jsonrpc-primitives = "0.14.0"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["rt", "macros"] }

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -222,7 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ) => {
                 // outcome.status != SuccessValue(`false`)
-                if near_primitives::serialize::from_base64(s)? != b"false" {
+                if near_primitives::serialize::from_base64(s).unwrap() == b"false" {
                     println!("(i) Account successfully created after {}s", delta);
                 } else {
                     println!("{:#?}", outcome);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,7 @@ mod tests {
 
     #[tokio::test]
     #[cfg(feature = "any")]
-    async fn any_typed_ok() -> Result<(), Box<dyn std::error::Error>> {
+    async fn any_typed_ok() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
 
         let tx_status = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!    use near_jsonrpc_primitives::types::transactions::TransactionInfo;
 //!
 //!    # #[tokio::main]
-//!    # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!    # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!    let mainnet_client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //!    let tx_status_request = methods::tx::RpcTransactionStatusRequest {
@@ -419,11 +419,9 @@ impl AsUrl for reqwest::Url {}
 mod tests {
     use crate::{methods, JsonRpcClient};
 
-    const RPC_SERVER_ADDR: &'static str = "https://archival-rpc.mainnet.near.org";
-
     #[tokio::test]
     async fn chk_status_testnet() {
-        let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
+        let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
 
         let status = client.call(methods::status::RpcStatusRequest).await;
 
@@ -437,7 +435,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "any")]
     async fn any_typed_ok() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
+        let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 
         let tx_status = client
             .call(methods::any::<methods::tx::RpcTransactionStatusRequest>(
@@ -466,7 +464,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "any")]
     async fn any_typed_err() -> Result<(), Box<dyn std::error::Error>> {
-        let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
+        let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 
         let tx_error = client
             .call(methods::any::<methods::tx::RpcTransactionStatusRequest>(
@@ -497,7 +495,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "any")]
     async fn any_untyped_ok() {
-        let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
+        let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 
         let status = client
             .call(
@@ -527,7 +525,7 @@ mod tests {
     #[tokio::test]
     #[cfg(feature = "any")]
     async fn any_untyped_err() {
-        let client = JsonRpcClient::connect(RPC_SERVER_ADDR);
+        let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 
         let tx_error = client
             .call(

--- a/src/methods/block.rs
+++ b/src/methods/block.rs
@@ -23,7 +23,7 @@
 //!
 //!       ```
 //!       # use near_jsonrpc_client::methods;
-//!       # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!       # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!       use near_primitives::types::{BlockReference, BlockId};
 //!
 //!       let request = methods::block::RpcBlockRequest {

--- a/src/methods/chunk.rs
+++ b/src/methods/chunk.rs
@@ -16,7 +16,7 @@
 //!       use near_primitives::types::BlockId;
 //!
 //!       # #[tokio::main]
-//!       # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!       # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!       let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //!       let request = methods::chunk::RpcChunkRequest {
@@ -72,7 +72,7 @@
 //!   use near_jsonrpc_primitives::types::chunks;
 //!
 //!   # #[tokio::main]
-//!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!   # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!   let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //!   let request = methods::chunk::RpcChunkRequest{

--- a/src/methods/light_client_proof.rs
+++ b/src/methods/light_client_proof.rs
@@ -5,7 +5,7 @@
 //! use near_primitives::types::TransactionOrReceiptId;
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //!
 //! let request = methods::light_client_proof::RpcLightClientExecutionProofRequest {

--- a/src/methods/tx.rs
+++ b/src/methods/tx.rs
@@ -8,7 +8,7 @@
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
 //! let tx_hash = "B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq".parse()?;
 //!


### PR DESCRIPTION
Updates nearcore dependencies to `0.14.0`. https://github.com/near/nearcore/pull/6918

This update restores compatibility with nodes, after a breaking change was introduced.