### PR TITLE
chore: version to `0.4.0-beta.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
-- Extracted all the RPC methods into their own modules instead of all being defined in the same `methods.rs` file. <https://github.com/near/near-jsonrpc-client-rs/pull/50>
-- Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
+## [0.4.0] - 2022-04-31
+
+- Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
 - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
 - Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
+- Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
+- Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
+- Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
 
 ## [0.3.0] - 2022-02-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.56.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.3.0"
+version = "0.4.0-beta.0"
 
 [dependencies]
 log = "0.4.17"


### PR DESCRIPTION
Scheduled release: 31-05-2022

Intermediate version before [`0.4.0`](https://github.com/near/near-jsonrpc-client-rs/pull/83).

Notable changes:

  - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
  - Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
  - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
  - Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
  - Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
  - Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
  - Extracted all the RPC methods into their own modules instead of all being defined in the same `methods.rs` file. <https://github.com/near/near-jsonrpc-client-rs/pull/50>