### PR TITLE
Add "rustls" feature flag to enable rustls-tls feature in reqwest instead of native-tls.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4.17"
 uuid = { version = "0.8", features = ["v4"], optional = true }
 borsh = "0.9"
 serde = "1.0.127"
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.4", features = ["json"], default-features = false }
 thiserror = "1.0.28"
 serde_json = "1.0.66"
 lazy_static = "1.4.0"
@@ -34,11 +34,13 @@ tokio = { version = "1.1", features = ["rt", "macros"] }
 env_logger = "0.9.0"
 
 [features]
-default = ["auth"]
+default = ["auth", "native-tls"]
 any = []
 auth = ["uuid"]
 sandbox = []
 adversarial = []
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [[example]]
 name = "auth"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ let partial_genesis = mainnet_client.call(genesis_config_request).await?;
 println!("{:#?}", partial_genesis);
 ```
 
+By default, `near-jsonrpc-client` uses `native-tls`. On Linux, this introduces a dependency on the system `openssl` library. In some situations, for example when cross-compiling, it can be problematic to depend on non-Rust libraries.
+
+If you wish to switch to an all-Rust TLS implementation, you may do so using the `rustls-tls` feature flag. Note that the `native-tls` feature is enabled by default. Therefore, to disable it and use `rustls-tls` instead, you must also use `default-features = false`. The default `auth` feature must then be declared explicitly.
+
+
+```toml
+# in Cargo.toml
+near-jsonrpc-client = { ..., default-features = false, features = ["auth","rustls-tls"] }
+```
+
+
 ## Releasing
 
 Versioning and releasing of this crate is automated and managed by [custom fork](https://github.com/miraclx/cargo-workspaces/tree/grouping-versioning-and-exclusion) of [`cargo-workspaces`](https://github.com/pksunkara/cargo-workspaces). To publish a new version of this crate, you can do so by bumping the `version` under the `[workspace.metadata.workspaces]` section in the [package manifest](https://github.com/near/near-jsonrpc-client-rs/blob/master/Cargo.toml) and submit a PR.


### PR DESCRIPTION
I ran into an issue while cross-compiling `near-jsonrpc-client-rs` that `openssl` was not available in my cross compiler environment. This adds a feature flag to enable the `rustls` version of `reqwest` instead, which works much better with cross compiling.