### PR TITLE
chore: update to 0.15.0 of NEAR crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Rust artifacts
 /target
 Cargo.lock
+
+# IDEs
+.idea
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cargo.lock
 # IDEs
 .idea
 .vscode
+
+# macOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/nearcore/pull/7248>
+
 ## [0.4.0] - 2022-04-31
 
 - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ near-chain-configs = "0.15.0"
 near-jsonrpc-primitives = "0.15.0"
 
 [dev-dependencies]
-tokio = { version = "1.1", features = ["rt", "macros"] }
+tokio = { version = "1.1", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/near/near-jsonrpc-client-rs"
 description = "Lower-level API for interfacing with the NEAR Protocol via JSONRPC"
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "api", "jsonrpc", "rpc", "async"]
-rust-version = "1.56.0"
+rust-version = "1.64.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ thiserror = "1.0.28"
 serde_json = "1.0.66"
 lazy_static = "1.4.0"
 
-near-crypto = "0.14.0"
-near-primitives = "0.14.0"
-near-chain-configs = "0.14.0"
-near-jsonrpc-primitives = "0.14.0"
+near-crypto = "0.15.0"
+near-primitives = "0.15.0"
+near-chain-configs = "0.15.0"
+near-jsonrpc-primitives = "0.15.0"
 
 [dev-dependencies]
 tokio = { version = "1.1", features = ["rt", "macros"] }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use near_jsonrpc_client::{methods, JsonRpcClient};
-use near_primitives::serialize::u128_dec_format;
+use near_primitives::serialize::dec_format;
 use near_primitives::types::*;
 
 #[derive(Debug, Deserialize)]
@@ -58,11 +58,11 @@ struct PartialGenesisConfig {
     chain_id: String,
     genesis_height: BlockHeight,
     epoch_length: BlockHeightDelta,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     min_gas_price: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     max_gas_price: Balance,
-    #[serde(with = "u128_dec_format")]
+    #[serde(with = "dec_format")]
     total_supply: Balance,
     validators: Vec<AccountInfo>,
 }

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -222,7 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             ) => {
                 // outcome.status != SuccessValue(`false`)
-                if near_primitives::serialize::from_base64(s).unwrap() == b"false" {
+                if s == b"false" {
                     println!("(i) Account successfully created after {}s", delta);
                 } else {
                     println!("{:#?}", outcome);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //!
 //!    # use near_jsonrpc_client::errors::JsonRpcError;
 //!    use near_jsonrpc_client::{methods, JsonRpcClient};
-//!    use near_primitives::serialize::u128_dec_format;
+//!    use near_primitives::serialize::dec_format;
 //!    use near_primitives::types::*;
 //!
 //!    #[derive(Debug, Deserialize)]
@@ -82,11 +82,11 @@
 //!        chain_id: String,
 //!        genesis_height: BlockHeight,
 //!        epoch_length: BlockHeightDelta,
-//!        #[serde(with = "u128_dec_format")]
+//!        #[serde(with = "dec_format")]
 //!        min_gas_price: Balance,
-//!        #[serde(with = "u128_dec_format")]
+//!        #[serde(with = "dec_format")]
 //!        max_gas_price: Balance,
-//!        #[serde(with = "u128_dec_format")]
+//!        #[serde(with = "dec_format")]
 //!        total_supply: Balance,
 //!        validators: Vec<AccountInfo>,
 //!    }


### PR DESCRIPTION
The NEAR crates need to be updated to unblock other libraries that are already or planning to use 0.15 of these crates.

A new version should be published following this pull.

Do note that there is a CI failure which I recommend the authors fix prior to pulling this in, but it is out of scope for this PR.