### PR TITLE
chore: update deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/nearcore/pull/7248>
+- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/110>
+- Updated other dependencies, with some general improvements. <https://github.com/near/near-jsonrpc-client-rs/pull/111>
 
 ## [0.4.0] - 2022-04-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ version = "0.4.0-beta.0"
 
 [dependencies]
 log = "0.4.17"
-uuid = { version = "1.1", features = ["v4"], optional = true }
-borsh = "0.9"
-serde = "1"
-reqwest = { version = "0.11", features = ["json"], default-features = false }
-thiserror = "1"
-serde_json = "1"
+uuid = { version = "1.1.2", features = ["v4"], optional = true }
+borsh = "0.9.3"
+serde = "1.0.145"
+reqwest = { version = "0.11.12", features = ["json"], default-features = false }
+thiserror = "1.0.37"
+serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
 near-crypto = "0.15.0"
@@ -30,8 +30,8 @@ near-chain-configs = "0.15.0"
 near-jsonrpc-primitives = "0.15.0"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.9"
+tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
+env_logger = "0.9.1"
 
 [features]
 default = ["auth", "native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ version = "0.4.0-beta.0"
 
 [dependencies]
 log = "0.4.17"
-uuid = { version = "0.8", features = ["v4"], optional = true }
+uuid = { version = "1.1", features = ["v4"], optional = true }
 borsh = "0.9"
-serde = "1.0.127"
-reqwest = { version = "0.11.4", features = ["json"], default-features = false }
-thiserror = "1.0.28"
-serde_json = "1.0.66"
+serde = "1"
+reqwest = { version = "0.11", features = ["json"], default-features = false }
+thiserror = "1"
+serde_json = "1"
 lazy_static = "1.4.0"
 
 near-crypto = "0.15.0"
@@ -30,8 +30,8 @@ near-chain-configs = "0.15.0"
 near-jsonrpc-primitives = "0.15.0"
 
 [dev-dependencies]
-tokio = { version = "1.1", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.9.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+env_logger = "0.9"
 
 [features]
 default = ["auth", "native-tls"]


### PR DESCRIPTION
Updated some, and just loosened the semver constraints for “trusted” dependencies.

@matklad, what do you think? Is this an antipattern?