### PR TITLE
chore: version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>
   <em>
-    Superceded by <a href="#040---2022-10-04">
+    Superseded by <a href="#040---2022-10-04">
       <code> 0.4.0 </code>
     </a>
   </em>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/nearcore/pull/7248>
+## [0.4.0.beta.1] - 2022-10-03
 
-## [0.4.0] - 2022-04-31
+- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/110>
+- Added `rustls-tls` feature flag to enable `rustls` as an alternative to `native-tls`. <https://github.com/near/near-jsonrpc-client-rs/pull/103>
+- Switched to using `log::debug!` instead of `log::info!` for debug logging. <https://github.com/near/near-jsonrpc-client-rs/pull/107>
+
+## [0.4.0.beta.0] - 2022-05-31
 
 - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
 - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0.beta.1] - 2022-10-03
+## [0.4.0] - 2022-10-03
 
-- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/110>
+- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/100>, <https://github.com/near/near-jsonrpc-client-rs/pull/110>
 - Added `rustls-tls` feature flag to enable `rustls` as an alternative to `native-tls`. <https://github.com/near/near-jsonrpc-client-rs/pull/103>
 - Switched to using `log::debug!` instead of `log::info!` for debug logging. <https://github.com/near/near-jsonrpc-client-rs/pull/107>
+- Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
+- Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
+- Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
+- Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
+- Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
 
-## [0.4.0.beta.0] - 2022-05-31
+## [0.4.0-beta.0] - 2022-05-31
 
 - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
 - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
@@ -45,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/near/near-jsonrpc-client-rs/releases/tag/v0.1.0>
 
-[unreleased]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0-beta.0...v0.4.0
+[0.4.0-beta.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...v0.4.0-beta.0
 [0.3.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/near/near-jsonrpc-client-rs/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <details>
 <summary>
   <em>
-    Superseded by <a href="#040---2022-10-04">
+    Superseded by <a href="https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0-beta.0...v0.4.0">
       <code> 0.4.0 </code>
     </a>
   </em>
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Release Page: <https://github.com/near/near-jsonrpc-client-rs/releases/tag/v0.1.0>
 
 [unreleased]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.4.0-beta.0...v0.4.0
+[0.4.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...v0.4.0
 [0.4.0-beta.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.3.0...v0.4.0-beta.0
 [0.3.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/near/near-jsonrpc-client-rs/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2022-10-03
+## [0.4.0] - 2022-10-04
 
 - Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/100>, <https://github.com/near/near-jsonrpc-client-rs/pull/110>
 - Updated other dependencies, with some general improvements. <https://github.com/near/near-jsonrpc-client-rs/pull/111>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0-beta.0] - 2022-05-31
 
-- Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
-- Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
-- Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
-- Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
-- Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
-- Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
+<details>
+<summary>
+  <em>
+    Superceded by <a href="#040---2022-10-04">
+      <code> 0.4.0 </code>
+    </a>
+  </em>
+</summary>
+
+> - Updated nearcore dependencies, fixing a previous breaking change. <https://github.com/near/near-jsonrpc-client-rs/pull/100>
+> - Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
+> - Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
+> - Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
+> - Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
+> - Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>
+
+</details>
 
 ## [0.3.0] - 2022-02-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.64.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.4.0-beta.0"
+version = "0.4.0"
 
 [dependencies]
 log = "0.4.17"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 
 [![crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
-![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.3.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.3.0)
+[![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)](#license)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.4.0-beta.1/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.4.0-beta.1)
 
 ## Usage
 
@@ -85,12 +85,10 @@ By default, `near-jsonrpc-client` uses `native-tls`. On Linux, this introduces a
 
 If you wish to switch to an all-Rust TLS implementation, you may do so using the `rustls-tls` feature flag. Note that the `native-tls` feature is enabled by default. Therefore, to disable it and use `rustls-tls` instead, you must also use `default-features = false`. The default `auth` feature must then be declared explicitly.
 
-
 ```toml
 # in Cargo.toml
 near-jsonrpc-client = { ..., default-features = false, features = ["auth","rustls-tls"] }
 ```
-
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 
-[![crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
+[![Crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
-[![MIT or Apache 2.0 licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)](#license)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.4.0-beta.1/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.4.0-beta.1)
+[![MIT or Apache 2.0 Licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)](#license)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.4.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.4.0)
 
 ## Usage
 


### PR DESCRIPTION
Scheduled release: 04-10-2022

Notable Changes:

- Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/100>, <https://github.com/near/near-jsonrpc-client-rs/pull/110>
- Updated other dependencies, with some general improvements. <https://github.com/near/near-jsonrpc-client-rs/pull/111>
- Added `rustls-tls` feature flag to enable `rustls` as an alternative to `native-tls`. <https://github.com/near/near-jsonrpc-client-rs/pull/103>
- Switched to using `log::debug!` instead of `log::info!` for debug logging. <https://github.com/near/near-jsonrpc-client-rs/pull/107>
- Fixed `gas_price` RPC method serialization. <https://github.com/near/near-jsonrpc-client-rs/pull/73>
- Fixed `query` method error deserialization. <https://github.com/near/near-jsonrpc-client-rs/pull/82>
- Reworked the `JsonRpcError`::`handler_error` method. <https://github.com/near/near-jsonrpc-client-rs/pull/99>
- Moved auth specific logic behind a feature flag. <https://github.com/near/near-jsonrpc-client-rs/pull/55>
- Added the `methods::to_json()` helper method for visualizing the serialization of the RPC methods. <https://github.com/near/near-jsonrpc-client-rs/pull/49>