### PR TITLE
&RpcMethod response handling should match RpcMethod's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed an issue where an `&RpcMethod`'s response was being parsed differently from an `RpcMethod`. <https://github.com/near/near-jsonrpc-client-rs/pull/114>
+
 ## [0.4.0] - 2022-10-04
 
 - Updated nearcore dependencies, which now requires a MSRV of `1.64.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/100>, <https://github.com/near/near-jsonrpc-client-rs/pull/110>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.64.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 log = "0.4.17"

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -42,6 +42,12 @@ where
     fn params(&self) -> Result<serde_json::Value, io::Error> {
         T::params(self)
     }
+
+    fn parse_handler_response(
+        response: serde_json::Value,
+    ) -> Result<Result<Self::Response, Self::Error>, serde_json::Error> {
+        T::parse_handler_response(response)
+    }
 }
 
 pub trait RpcHandlerResponse: serde::de::DeserializeOwned {

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -92,6 +92,37 @@ struct LegacyQueryError {
 mod tests {
     use {super::*, crate::*};
 
+    /// This test is to make sure the method executor treats `&RpcMethod`s the same as `RpcMethod`s.
+    #[tokio::test]
+    async fn test_unknown_method() -> Result<(), Box<dyn std::error::Error>> {
+        let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
+
+        let request = RpcQueryRequest {
+            block_reference: near_primitives::types::BlockReference::latest(),
+            request: near_primitives::views::QueryRequest::CallFunction {
+                account_id: "testnet".parse()?,
+                method_name: "some_unavailable_method".to_string(),
+                args: vec![].into(),
+            },
+        };
+
+        let response_err = client.call(&request).await.unwrap_err();
+
+        assert!(
+            matches!(
+                response_err.handler_error(),
+                Some(RpcQueryError::ContractExecutionError {
+                    ref vm_error,
+                    ..
+                }) if vm_error.contains("FunctionCallError(MethodResolveError(MethodNotFound))")
+            ),
+            "this is unexpected: {:#?}",
+            response_err
+        );
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_unknown_access_key() -> Result<(), Box<dyn std::error::Error>> {
         let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
@@ -117,7 +148,7 @@ mod tests {
                     ..
                 }) if public_key.to_string() == "ed25519:9KnjTjL6vVoM8heHvCcTgLZ67FwFkiLsNtknFAVsVvYY"
             ),
-            "{:#?}",
+            "this is unexpected: {:#?}",
             response_err
         );
 
@@ -133,7 +164,6 @@ mod tests {
                 near_primitives::types::BlockId::Height(63503911),
             ),
             request: near_primitives::views::QueryRequest::CallFunction {
-                #[allow(deprecated)]
                 account_id: "miraclx.testnet".parse()?,
                 method_name: "".to_string(),
                 args: vec![].into(),
@@ -151,7 +181,7 @@ mod tests {
                     ..
                 }) if vm_error.contains("FunctionCallError(MethodResolveError(MethodEmptyName))")
             ),
-            "{:#?}",
+            "this is unexpected: {:#?}",
             response_err
         );
 


### PR DESCRIPTION
Small nit, but the client was parsing `&RpcMethod`'s differently from `RpcMethod`s.

Leading to the `data did not match any variant of untagged enum QueryResponseKind` error when you run `client.call(&method)`.