### PR TITLE
introduce Authorization::bearer helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `ApiKey::new` now accepts byte arrays and byte slices. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
+- `Authorization::bearer` method for token-authenticated requests. <https://github.com/near/near-jsonrpc-client-rs/pull/121>
 - `ApiKey::as_bytes` returns a byte slice of the key without utf-8 validation. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 
 ### Changed

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -44,6 +44,7 @@ impl crate::header::HeaderEntry for ApiKey {
     }
 }
 
+/// HTTP Authorization scheme.
 #[derive(Eq, Hash, Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum AuthorizationScheme {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,6 @@
+use std::ops::{Index, RangeFrom};
+use std::str;
+
 use super::header::{HeaderValue, InvalidHeaderValue, ToStrError};
 
 /// NEAR JSON RPC API key.
@@ -17,7 +20,7 @@ impl ApiKey {
         })
     }
 
-    /// Returns a `&str` slice if the API Key only contains visible ASCII chars.
+    /// Returns a string slice if the API Key only contains visible ASCII chars.
     pub fn to_str(&self) -> Result<&str, ToStrError> {
         self.0.to_str()
     }
@@ -41,21 +44,94 @@ impl crate::header::HeaderEntry for ApiKey {
     }
 }
 
+#[derive(Eq, Hash, Copy, Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum AuthorizationScheme {
+    Bearer,
+}
+
+/// NEAR JSON RPC authorization header.
+#[derive(Eq, Hash, Clone, Debug, PartialEq)]
+pub struct Authorization(AuthorizationScheme, HeaderValue);
+
+impl Authorization {
+    pub const HEADER_NAME: &'static str = "Authorization";
+
+    /// Creates a new authorization token with the bearer scheme.
+    pub fn bearer<T: AsRef<str>>(token: T) -> Result<Self, InvalidHeaderValue> {
+        HeaderValue::from_bytes(&[b"Bearer ", token.as_ref().as_bytes()].concat()).map(
+            |mut token| {
+                Authorization(AuthorizationScheme::Bearer, {
+                    token.set_sensitive(true);
+                    token
+                })
+            },
+        )
+    }
+
+    /// Returns the scheme of the authorization header.
+    pub fn scheme(&self) -> AuthorizationScheme {
+        self.0
+    }
+
+    /// Returns the token as a string slice.
+    pub fn as_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(self.as_bytes()) }
+    }
+
+    /// Returns the token as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.strip_scheme(self.1.as_bytes())
+    }
+
+    fn strip_scheme<'a, T: Index<RangeFrom<usize>> + ?Sized>(&self, token: &'a T) -> &'a T::Output {
+        &token[match self.0 {
+            AuthorizationScheme::Bearer => 7,
+        }..]
+    }
+}
+
+impl crate::header::HeaderEntry for Authorization {
+    type HeaderName = &'static str;
+    type HeaderValue = HeaderValue;
+
+    fn header_name(&self) -> &Self::HeaderName {
+        &Self::HEADER_NAME
+    }
+
+    fn header_pair(self) -> (Self::HeaderName, Self::HeaderValue) {
+        (Self::HEADER_NAME, self.1)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn sensitive_debug() {
-        let api_key = ApiKey::new("this is a very secret secret").unwrap();
+        let api_key = ApiKey::new("this is a very secret secret").expect("valid API key");
 
         assert_eq!(format!("{:?}", api_key), "ApiKey(Sensitive)");
 
         assert_eq!(
-            api_key.to_str().expect("valid secret"),
+            api_key.to_str().expect("valid utf8 secret"),
             "this is a very secret secret"
         );
 
         assert_eq!(api_key.as_bytes(), b"this is a very secret secret");
+    }
+
+    #[test]
+    fn bearer_token() {
+        let token = Authorization::bearer("this is a very secret token").expect("valid token");
+
+        assert_eq!(format!("{:?}", token), "Authorization(Bearer, Sensitive)");
+
+        assert_eq!(token.scheme(), AuthorizationScheme::Bearer);
+
+        assert_eq!(token.as_str(), "this is a very secret token");
+
+        assert_eq!(token.as_bytes(), b"this is a very secret token");
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,4 @@
-//! Helpers for Client Authentication.
+//! Helpers for client authentication.
 //!
 //! Some RPC nodes will require authentication before requests can be sent to them.
 //!

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,4 +1,4 @@
-//! Client Headers.
+//! Client headers.
 //!
 //! This module includes everything you need to build valid header entries.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!   - a `Response` type (e.g [`methods::query::RpcQueryResponse`])
 //!   - and an `Error` type (e.g [`methods::query::RpcQueryError`])
 //!
-//! Calling a constructed request on a client returns with the result and error types for that method.
+//! Calling a constructed request on a client returns with the response and error types for that method.
 //!
 //! ## Examples
 //!
@@ -299,10 +299,8 @@ impl JsonRpcClient {
     /// let client = JsonRpcClient::connect("https://rpc.testnet.near.org");
     /// let client = client.header(("user-agent", "someclient/0.1.0"))?; // <- returns a result
     ///
-    /// # #[cfg(feature = "auth")]
     /// use near_jsonrpc_client::auth;
     ///
-    /// # #[cfg(feature = "auth")]
     /// let client = client.header(
     ///     auth::ApiKey::new("cadc4c83-5566-4c94-aa36-773605150f44")?, // <- error handling here
     /// ); // <- returns the client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@ impl JsonRpcClient {
         })?;
 
         log::debug!("request payload: {:#}", request_payload);
+        log::debug!("request headers: {:#?}", self.headers());
 
         let request_payload = serde_json::to_vec(&request_payload).map_err(|err| {
             JsonRpcError::TransportError(RpcTransportError::SendError(
@@ -228,6 +229,7 @@ impl JsonRpcClient {
                 JsonRpcTransportSendError::PayloadSendError(err),
             ))
         })?;
+        log::debug!("response headers: {:#?}", response.headers());
         match response.status() {
             reqwest::StatusCode::OK => {}
             non_ok_status => {


### PR DESCRIPTION
Resolves #118.

Introduces the `Authorization::bearer` method that adds an equivalent `Authorization: Bearer ...` entry into the request headers.

This function does no input validation beyond that it's a header value, not that it's a valid JWT.

We offload the guarantee of it being a valid utf-8 string to the caller.