### PR TITLE
updated near-primitives and associated crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated nearcore dependencies to `0.16.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/122>
 - `ApiKey::new` no longer requres the input of a valid UUID. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 - `Debug` on `ApiKey` doesn't reveal the key anymore. <https://github.com/near/near-jsonrpc-client-rs/pull/120>
 - The `auth` module is no longer feature gated. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
@@ -25,12 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `ApiKey::as_str` method with `ApiKey::to_str`, now returning a `Result`. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 - Replaced the `InvalidApiKey` error with `InvalidHeaderValue` re-exported from `http`. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 - Removed `Display` on `ApiKey`. <https://github.com/near/near-jsonrpc-client-rs/pull/117>
-
-## [0.4.2] - 2023-02-24
-- update `near-primitives` and associated crates to `0.16.0`
-- downgrade tokio to `1.19.0` to be compatible with `near-primitives` subdependency versions of `tokio`
-- fix signature type bug introduced in https://github.com/near/nearcore/pull/8460
-- updated error msg str to exclude FunctionCallError
 
 ## [0.4.1] - 2022-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated nearcore dependencies to `0.16.0`. <https://github.com/near/near-jsonrpc-client-rs/pull/122>
+- Updated nearcore dependencies to `0.16.0`, which now requires a MSRV of `1.67.1`. <https://github.com/near/near-jsonrpc-client-rs/pull/122>
 - `ApiKey::new` no longer requres the input of a valid UUID. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 - `Debug` on `ApiKey` doesn't reveal the key anymore. <https://github.com/near/near-jsonrpc-client-rs/pull/120>
 - The `auth` module is no longer feature gated. <https://github.com/near/near-jsonrpc-client-rs/pull/119>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced the `InvalidApiKey` error with `InvalidHeaderValue` re-exported from `http`. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
 - Removed `Display` on `ApiKey`. <https://github.com/near/near-jsonrpc-client-rs/pull/117>
 
+## [0.4.2] - 2023-02-24
+- update `near-primitives` and associated crates to `0.16.0`
+- downgrade tokio to `1.19.0` to be compatible with `near-primitives` subdependency versions of `tokio`
+- fix signature type bug introduced in https://github.com/near/nearcore/pull/8460
+- updated error msg str to exclude FunctionCallError
+
 ## [0.4.1] - 2022-11-11
 
 - Fixed an issue where an `&RpcMethod`'s response was being parsed differently from an `RpcMethod`. <https://github.com/near/near-jsonrpc-client-rs/pull/114>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ near-chain-configs = "0.16.0"
 near-jsonrpc-primitives = "0.16.0"
 
 [dev-dependencies]
-tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.19.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ thiserror = "1.0.37"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.15.0"
-near-primitives = "0.15.0"
-near-chain-configs = "0.15.0"
-near-jsonrpc-primitives = "0.15.0"
+near-crypto = "0.16.0"
+near-primitives = "0.16.0"
+near-chain-configs = "0.16.0"
+near-jsonrpc-primitives = "0.16.0"
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ near-chain-configs = "0.16.0"
 near-jsonrpc-primitives = "0.16.0"
 
 [dev-dependencies]
-tokio = { version = "1.19.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/near/near-jsonrpc-client-rs"
 description = "Lower-level API for interfacing with the NEAR Protocol via JSONRPC"
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "api", "jsonrpc", "rpc", "async"]
-rust-version = "1.64.0"
+rust-version = "1.67.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -145,7 +145,7 @@ pub use adversarial::adv_check_store;
 pub fn to_json<M: RpcMethod>(method: &M) -> Result<serde_json::Value, io::Error> {
     let request_payload = near_jsonrpc_primitives::message::Message::request(
         method.method_name().to_string(),
-        Option::from(method.params().unwrap()).into(),
+        method.params()?,
     );
 
     Ok(json!(request_payload))
@@ -178,7 +178,7 @@ mod common {
         tx: &near_primitives::transaction::SignedTransaction,
     ) -> Result<String, io::Error> {
         Ok(near_primitives::serialize::to_base64(
-            &borsh::BorshSerialize::try_to_vec(&tx)?,
+            borsh::BorshSerialize::try_to_vec(&tx)?,
         ))
     }
 

--- a/src/methods/mod.rs
+++ b/src/methods/mod.rs
@@ -145,7 +145,7 @@ pub use adversarial::adv_check_store;
 pub fn to_json<M: RpcMethod>(method: &M) -> Result<serde_json::Value, io::Error> {
     let request_payload = near_jsonrpc_primitives::message::Message::request(
         method.method_name().to_string(),
-        Some(method.params()?),
+        Option::from(method.params().unwrap()).into(),
     );
 
     Ok(json!(request_payload))

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -114,7 +114,7 @@ mod tests {
                 Some(RpcQueryError::ContractExecutionError {
                     ref vm_error,
                     ..
-                }) if vm_error.contains("FunctionCallError(MethodResolveError(MethodNotFound))")
+                }) if vm_error.contains("MethodResolveError(MethodNotFound)")
             ),
             "this is unexpected: {:#?}",
             response_err
@@ -179,7 +179,7 @@ mod tests {
                     ref vm_error,
                     block_height: 63503911,
                     ..
-                }) if vm_error.contains("FunctionCallError(MethodResolveError(MethodEmptyName))")
+                }) if vm_error.contains("MethodResolveError(MethodEmptyName)")
             ),
             "this is unexpected: {:#?}",
             response_err


### PR DESCRIPTION
needed for releasing the relayer used for meta transactions https://github.com/near/pagoda-relayer-rs/pull/1 and cli changes https://github.com/near/near-cli-rs/pull/151
- update `near-primitives` and associated crates to `0.16.0`
- downgrade tokio to `1.19.0` to be compatible with `near-primitives` subdependency versions of `tokio`
- fix signature type bug introduced in https://github.com/near/nearcore/pull/8460
- updated error msg str - see https://github.com/near/near-jsonrpc-client-rs/pull/122#issuecomment-1442527306
- bump `rust-version` to `1.67.1` after https://github.com/near/nearcore/pull/8456.