### PR TITLE
chore: version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-02-24
+
 ### Added
 
 - `ApiKey::new` now accepts byte arrays and byte slices. <https://github.com/near/near-jsonrpc-client-rs/pull/119>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.64.0"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 log = "0.4.17"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 [![Crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
 [![MIT or Apache 2.0 Licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)](#license)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.4.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.4.0)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.5.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.5.0)
 
 ## Usage
 


### PR DESCRIPTION
Scheduled Release: 24-02-2023

## Notable Changes

### Added

- `ApiKey::new` now accepts byte arrays and byte slices. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
- `Authorization::bearer` method for token-authenticated requests. <https://github.com/near/near-jsonrpc-client-rs/pull/121>
- `ApiKey::as_bytes` returns a byte slice of the key without utf-8 validation. <https://github.com/near/near-jsonrpc-client-rs/pull/119>

### Changed

- Updated nearcore dependencies to `0.16.0`, which now requires a MSRV of `1.67.1`. <https://github.com/near/near-jsonrpc-client-rs/pull/122>
- `ApiKey::new` no longer requres the input of a valid UUID. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
- `Debug` on `ApiKey` doesn't reveal the key anymore. <https://github.com/near/near-jsonrpc-client-rs/pull/120>
- The `auth` module is no longer feature gated. <https://github.com/near/near-jsonrpc-client-rs/pull/119>

### Breaking

- Removed the `auth::IntoApiKey` trait, any thing you can get a byte slice from is now a valid `ApiKey` input. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
- Replaced the `ApiKey::as_str` method with `ApiKey::to_str`, now returning a `Result`. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
- Replaced the `InvalidApiKey` error with `InvalidHeaderValue` re-exported from `http`. <https://github.com/near/near-jsonrpc-client-rs/pull/119>
- Removed `Display` on `ApiKey`. <https://github.com/near/near-jsonrpc-client-rs/pull/117>