### PR TITLE
chore: bump borsh to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.5.0"
 
 [dependencies]
 log = "0.4.17"
-borsh = "0.9.3"
+borsh = "0.10.2"
 serde = "1.0.145"
 reqwest = { version = "0.11.12", features = ["json"], default-features = false }
 thiserror = "1.0.37"
@@ -30,7 +30,7 @@ near-jsonrpc-primitives = "0.16.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.9.1"
+env_logger = "0.10.0"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
The PR bumps `borsh` dependency to 0.10.2.