### PR TITLE
chore: version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2023-03-22
+
+- Updated `borsh` to `0.10.2`. <https://github.com/near/near-jsonrpc-client-rs/pull/124>
+
 ## [0.5.0] - 2023-02-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.67.1"
 
 # cargo-workspaces
 [workspace.metadata.workspaces]
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 log = "0.4.17"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lower-level API for interfacing with the NEAR Protocol via JSONRPC.
 [![Crates.io](https://img.shields.io/crates/v/near-jsonrpc-client?label=latest)](https://crates.io/crates/near-jsonrpc-client)
 [![Documentation](https://docs.rs/near-jsonrpc-client/badge.svg)](https://docs.rs/near-jsonrpc-client)
 [![MIT or Apache 2.0 Licensed](https://img.shields.io/crates/l/near-jsonrpc-client.svg)](#license)
-[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.5.0/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.5.0)
+[![Dependency Status](https://deps.rs/crate/near-jsonrpc-client/0.5.1/status.svg)](https://deps.rs/crate/near-jsonrpc-client/0.5.1)
 
 ## Usage
 


### PR DESCRIPTION
Scheduled Release: 22-03-2023

Updated `borsh` to `0.10.2`. <https://github.com/near/near-jsonrpc-client-rs/pull/124>
