### PR TITLE
feat: Added a new example to view contract state

### DIFF
--- a/examples/contract_view_state.rs
+++ b/examples/contract_view_state.rs
@@ -1,0 +1,33 @@
+use near_jsonrpc_client::methods;
+use near_jsonrpc_primitives::types::query::QueryResponseKind;
+use near_primitives::types::{AccountId, BlockReference, Finality};
+use near_primitives::views::QueryRequest;
+
+mod utils;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    let client = utils::select_network()?;
+
+    let contract_id: AccountId =
+        utils::input("Enter the contract whose state you want to inspect: ")?.parse()?;
+
+    let request = methods::query::RpcQueryRequest {
+        block_reference: BlockReference::Finality(Finality::Final),
+        request: QueryRequest::ViewState {
+            account_id: contract_id.clone(),
+            prefix: near_primitives::types::StoreKey::from(Vec::new()),
+            include_proof: false,
+        },
+    };
+
+    let response = client.call(request).await?;
+
+    if let QueryResponseKind::ViewState(result) = response.kind {
+        println!("{:#?}", result);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This is a barebones example that dumps the low-level state as is. In the future we might want to make it nicer or point to near.cli.rs for the demo (https://github.com/near/near-cli-rs/issues/223)