### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.7.0...v0.8.0) - 2024-01-21
+
+### Other
+- [**breaking**] Upgraded NEAR crates to 0.20.0 release ([#137](https://github.com/near/near-jsonrpc-client-rs/pull/137))
+
 ## [0.7.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.6.0...v0.7.0) - 2024-01-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.7.0 -> 0.8.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.7.0...v0.8.0) - 2024-01-21

### Other
- [**breaking**] Upgraded NEAR crates to 0.20.0 release ([#137](https://github.com/near/near-jsonrpc-client-rs/pull/137))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).