### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.8.0...v0.9.0) - 2024-04-22
+
+### Added
+- Upgrade near-primitives to 0.21.x and refactor the API adding `wait_until` flag, drop `check_tx` method ([#136](https://github.com/near/near-jsonrpc-client-rs/pull/136))
+
+### Other
+- removed array creation for parameters in fn params() implementation for send_tx method ([#142](https://github.com/near/near-jsonrpc-client-rs/pull/142))
+
 ## [0.8.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.7.0...v0.8.0) - 2024-01-21
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.8.0 -> 0.9.0 (⚠️ API breaking changes)

### ⚠️ `near-jsonrpc-client` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RpcTransactionStatusRequest.wait_until in /tmp/.tmpXtONiN/near-jsonrpc-client-rs/src/methods/experimental/tx_status.rs:43
  field RpcTransactionStatusRequest.wait_until in /tmp/.tmpXtONiN/near-jsonrpc-client-rs/src/methods/tx.rs:46

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/module_missing.ron

Failed in:
  mod near_jsonrpc_client::methods::EXPERIMENTAL_check_tx, previously in file /tmp/.tmpbIalrs/near-jsonrpc-client/src/methods/experimental/check_tx.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_missing.ron

Failed in:
  struct near_jsonrpc_client::methods::EXPERIMENTAL_check_tx::RpcCheckTxRequest, previously in file /tmp/.tmpbIalrs/near-jsonrpc-client/src/methods/experimental/check_tx.rs:63
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.8.0...v0.9.0) - 2024-04-22

### Added
- Upgrade near-primitives to 0.21.x and refactor the API adding `wait_until` flag, drop `check_tx` method ([#136](https://github.com/near/near-jsonrpc-client-rs/pull/136))

### Other
- removed array creation for parameters in fn params() implementation for send_tx method ([#142](https://github.com/near/near-jsonrpc-client-rs/pull/142))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).