### PR TITLE
Fix: removed array creation for parameters in fn params() implementation for send_tx method

### DIFF
--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -70,7 +70,7 @@ impl From<RpcBroadcastTxAsyncRequest>
     fn from(this: RpcBroadcastTxAsyncRequest) -> Self {
         Self {
             signed_transaction: this.signed_transaction,
-            wait_until: near_primitives::views::TxExecutionStatus::default(),
+            wait_until: near_primitives::views::TxExecutionStatus::None,
         }
     }
 }

--- a/src/methods/send_tx.rs
+++ b/src/methods/send_tx.rs
@@ -73,10 +73,10 @@ impl RpcMethod for RpcSendTransactionRequest {
     }
 
     fn params(&self) -> Result<serde_json::Value, io::Error> {
-        Ok(json!([
-            common::serialize_signed_transaction(&self.signed_transaction)?,
-            self.wait_until
-        ]))
+        Ok(json!({
+                "signed_tx_base64": common::serialize_signed_transaction(&self.signed_transaction)?,
+                "wait_until": self.wait_until
+        }))
     }
 }
 


### PR DESCRIPTION
- Fixes #141: removed array creation for parameters in fn params() implementation for send_tx method
- Fixes #143: From trait for RpcBroadcastTxAsyncRequest