### PR TITLE
expose ChunkReference type used in chunk call

### DIFF
--- a/src/methods/chunk.rs
+++ b/src/methods/chunk.rs
@@ -92,7 +92,7 @@
 //!   ```
 use super::*;
 
-pub use near_jsonrpc_primitives::types::chunks::{RpcChunkError, RpcChunkRequest};
+pub use near_jsonrpc_primitives::types::chunks::{ChunkReference, RpcChunkError, RpcChunkRequest};
 
 pub type RpcChunkResponse = near_primitives::views::ChunkView;
 


### PR DESCRIPTION
Maybe intentional, PRing in case it's preferred to not have to import primitives to use this method :)