### PR TITLE
chore: upgraded near libraries and reqwest to the latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,19 @@ rust-version = "1.67.1"
 log = "0.4.17"
 borsh = "1.3.0"
 serde = "1.0.145"
-reqwest = { version = "0.11.12", features = ["json"], default-features = false }
+reqwest = { version = "0.12", features = ["json"], default-features = false }
 thiserror = "1.0.37"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.21.1"
-near-primitives = "0.21.1"
-near-chain-configs = "0.21.1"
-near-jsonrpc-primitives = "0.21.1"
+near-crypto = "0.22"
+near-primitives = "0.22"
+near-chain-configs = "0.22"
+near-jsonrpc-primitives = "0.22"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10.0"
+env_logger = "0.11.0"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
I have updated the near-core libraries to the latest 0.22 release.