### PR TITLE
chore: Updated near-deps to 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "1.0.37"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.22"
-near-primitives = "0.22"
-near-chain-configs = "0.22"
-near-jsonrpc-primitives = "0.22"
+near-crypto = "0.23"
+near-primitives = "0.23"
+near-chain-configs = "0.23"
+near-jsonrpc-primitives = "0.23"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "1.0.37"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.23"
-near-primitives = "0.23"
-near-chain-configs = "0.23"
-near-jsonrpc-primitives = "0.23"
+near-crypto = ">0.22,<0.24"
+near-primitives = ">0.22,<0.24"
+near-chain-configs = ">0.22,<0.24"
+near-jsonrpc-primitives = ">0.22,<0.24"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
~Technically it is a breaking change since we now depend on the newer version of near-* crates and thus the upstream dependencies should also update them.~

It is not a breaking change since developers can still use the older near-* versions