### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.0...v0.10.1) - 2024-06-18
+
+### Other
+- Updated near-deps to 0.23.0 ([#148](https://github.com/near/near-jsonrpc-client-rs/pull/148))
+
 ## [0.10.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.9.0...v0.10.0) - 2024-06-07
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.0...v0.10.1) - 2024-06-18

### Other
- Updated near-deps to 0.23.0 ([#148](https://github.com/near/near-jsonrpc-client-rs/pull/148))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).