### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.1...v0.10.2) - 2024-08-09
+
+### Other
+- updated near-* crates to allow 0.24.0 in addition to all the previously supported versions ([#151](https://github.com/near/near-jsonrpc-client-rs/pull/151))
+
 ## [0.10.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.0...v0.10.1) - 2024-06-18
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.10.1 -> 0.10.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.1...v0.10.2) - 2024-08-09

### Other
- updated near-* crates to allow 0.24.0 in addition to all the previously supported versions ([#151](https://github.com/near/near-jsonrpc-client-rs/pull/151))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).