### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.11.0...v0.11.1) - 2024-08-21
+
+### Other
+- updated near-* to 0.25.0 ([#154](https://github.com/near/near-jsonrpc-client-rs/pull/154))
+
 ## [0.11.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.10.1...v0.11.0) - 2024-08-09
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.11.0...v0.11.1) - 2024-08-21
+## [0.12.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.11.0...v0.12.0) - 2024-08-21
 
 ### Other
 - updated near-* to 0.25.0 ([#154](https://github.com/near/near-jsonrpc-client-rs/pull/154))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.11.0 -> 0.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.11.0...v0.12.0) - 2024-08-21

### Other
- updated near-* to 0.25.0 ([#154](https://github.com/near/near-jsonrpc-client-rs/pull/154))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).