### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.14.0...v0.15.0) - 2024-12-10
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.28 release (#163)
+
 ## [0.14.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.13.0...v0.14.0) - 2024-11-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `near-jsonrpc-client`: 0.14.0 -> 0.15.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.14.0...v0.15.0) - 2024-12-10

### Other

- [**breaking**] updates near-* dependencies to 0.28 release (#163)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).