### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.15.1...v0.16.0) - 2025-03-06
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.29 release ([#169](https://github.com/near/near-jsonrpc-client-rs/pull/169))
+- added CODEOWNERS ([#167](https://github.com/near/near-jsonrpc-client-rs/pull/167))
+
 ## [0.15.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.15.0...v0.15.1) - 2024-12-13
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.15.1 -> 0.16.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.15.1...v0.16.0) - 2025-03-06

### Other

- [**breaking**] updates near-* dependencies to 0.29 release ([#169](https://github.com/near/near-jsonrpc-client-rs/pull/169))
- added CODEOWNERS ([#167](https://github.com/near/near-jsonrpc-client-rs/pull/167))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).