### PR TITLE
chore!: updates near-* dependencies to 0.29 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = ">0.22,<0.29"
-near-primitives = { version = ">0.22,<0.29", features = ["test_utils"] }
-near-chain-configs = ">0.22,<0.29"
-near-jsonrpc-primitives = ">0.22,<0.29"
+near-crypto = ">0.22,<0.30"
+near-primitives = { version = ">0.22,<0.30", features = ["test_utils"] }
+near-chain-configs = ">0.22,<0.30"
+near-jsonrpc-primitives = ">0.22,<0.30"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/contract_change_method_commit.rs
+++ b/examples/contract_change_method_commit.rs
@@ -1,4 +1,3 @@
-use near_crypto::Signer;
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction, TransactionV0};
@@ -23,8 +22,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .call(methods::query::RpcQueryRequest {
             block_reference: BlockReference::latest(),
             request: near_primitives::views::QueryRequest::ViewAccessKey {
-                account_id: signer.account_id.clone(),
-                public_key: signer.public_key.clone(),
+                account_id: signer.get_account_id(),
+                public_key: signer.public_key().clone(),
             },
         })
         .await?;
@@ -38,8 +37,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rating = utils::input("Enter a rating: ")?.parse::<f32>()?;
 
     let transaction = TransactionV0 {
-        signer_id: signer.account_id.clone(),
-        public_key: signer.public_key.clone(),
+        signer_id: signer.get_account_id(),
+        public_key: signer.public_key().clone(),
         nonce: current_nonce + 1,
         receiver_id: "nosedive.testnet".parse()?,
         block_hash: access_key_query_response.block_hash,
@@ -57,7 +56,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let request = methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
-        signed_transaction: Transaction::V0(transaction).sign(&Signer::InMemory(signer)),
+        signed_transaction: Transaction::V0(transaction).sign(&signer),
     };
 
     let response = client.call(request).await?;

--- a/examples/send_tx.rs
+++ b/examples/send_tx.rs
@@ -25,8 +25,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .call(methods::query::RpcQueryRequest {
             block_reference: BlockReference::latest(),
             request: near_primitives::views::QueryRequest::ViewAccessKey {
-                account_id: signer.account_id.clone(),
-                public_key: signer.public_key.clone(),
+                account_id: signer.get_account_id(),
+                public_key: signer.public_key().clone(),
             },
         })
         .await?;
@@ -40,8 +40,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rating = utils::input("Enter a rating: ")?.parse::<f32>()?;
 
     let transaction = Transaction::V0(TransactionV0 {
-        signer_id: signer.account_id.clone(),
-        public_key: signer.public_key.clone(),
+        signer_id: signer.get_account_id(),
+        public_key: signer.public_key(),
         nonce: current_nonce + 1,
         receiver_id: "nosedive.testnet".parse()?,
         block_hash: access_key_query_response.block_hash,
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tx_hash = transaction.get_hash_and_size().0;
 
     let request = methods::send_tx::RpcSendTransactionRequest {
-        signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(signer.clone())),
+        signed_transaction: transaction.sign(&signer),
         wait_until: wait_until.clone(),
     };
 
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .call(methods::tx::RpcTransactionStatusRequest {
                         transaction_info: TransactionInfo::TransactionId {
                             tx_hash,
-                            sender_account_id: signer.account_id.clone(),
+                            sender_account_id: signer.get_account_id(),
                         },
                         wait_until: wait_until.clone(),
                     })

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.80"
+channel = "stable"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/methods/broadcast_tx_async.rs
+++ b/src/methods/broadcast_tx_async.rs
@@ -29,8 +29,8 @@
 //! let rating = "4.5".parse::<f32>()?;
 //!
 //! let transaction = Transaction::V0(TransactionV0 {
-//!     signer_id: signer.account_id.clone(),
-//!     public_key: signer.public_key.clone(),
+//!     signer_id: signer.get_account_id(),
+//!     public_key: signer.public_key().clone(),
 //!     nonce: 10223934 + 1,
 //!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
 //!     block_hash: "AUDcb2iNUbsmCsmYGfGuKzyXKimiNcCZjBKTVsbZGnoH".parse()?,
@@ -48,7 +48,7 @@
 //! });
 //!
 //! let request = methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest {
-//!     signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(signer))
+//!     signed_transaction: transaction.sign(&signer)
 //! };
 //! # Ok(())
 //! # }

--- a/src/methods/broadcast_tx_commit.rs
+++ b/src/methods/broadcast_tx_commit.rs
@@ -30,8 +30,8 @@
 //! let rating = "4.5".parse::<f32>()?;
 //!
 //! let transaction = Transaction::V0(TransactionV0 {
-//!     signer_id: signer.account_id.clone(),
-//!     public_key: signer.public_key.clone(),
+//!     signer_id: signer.get_account_id(),
+//!     public_key: signer.public_key().clone(),
 //!     nonce: 904565 + 1,
 //!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
 //!     block_hash: "AUDcb2iNUbsmCsmYGfGuKzyXKimiNcCZjBKTVsbZGnoH".parse()?,
@@ -49,7 +49,7 @@
 //! });
 //!
 //! let request = methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
-//!     signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(signer))
+//!     signed_transaction: transaction.sign(&signer)
 //! };
 //! # Ok(())
 //! # }

--- a/src/methods/send_tx.rs
+++ b/src/methods/send_tx.rs
@@ -31,8 +31,8 @@
 //! let rating = "4.5".parse::<f32>()?;
 //!
 //! let transaction = Transaction::V0(TransactionV0 {
-//!     signer_id: signer.account_id.clone(),
-//!     public_key: signer.public_key.clone(),
+//!     signer_id: signer.get_account_id(),
+//!     public_key: signer.public_key().clone(),
 //!     nonce: 904565 + 1,
 //!     receiver_id: "nosedive.testnet".parse::<AccountId>()?,
 //!     block_hash: "AUDcb2iNUbsmCsmYGfGuKzyXKimiNcCZjBKTVsbZGnoH".parse()?,
@@ -50,7 +50,7 @@
 //! });
 //!
 //! let request = methods::send_tx::RpcSendTransactionRequest {
-//!     signed_transaction: transaction.sign(&near_crypto::Signer::InMemory(signer)),
+//!     signed_transaction: transaction.sign(&signer),
 //!     wait_until: TxExecutionStatus::IncludedFinal,
 //! };
 //! # Ok(())

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -12,11 +12,11 @@
 //!
 //!   # #[tokio::main]
 //!   # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//!   let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//!   let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
 //!
 //!   let request = methods::validators::RpcValidatorRequest {
 //!       epoch_reference: EpochReference::EpochId(
-//!           "9xrjdZmgjoVkjVE3ui7tY37x9Mkw5wH385qNXE6cho7T".parse()?,
+//!           "ECjBFyob3eKjDnDWDrbX4pkiSbGRAGyiHbS4ZVY8dxvD".parse()?,
 //!       )
 //!   };
 //!
@@ -38,7 +38,7 @@
 //!
 //!   # #[tokio::main]
 //!   # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!   let client = JsonRpcClient::connect("https://archival-rpc.mainnet.near.org");
+//!   let client = JsonRpcClient::connect("https://archival-rpc.testnet.near.org");
 //!
 //!   let request = methods::validators::RpcValidatorRequest {
 //!       epoch_reference: EpochReference::Latest


### PR DESCRIPTION
@race-of-sloths

For now, 2.5.0 is rolled back for nodes, so we don't have a running RPC node with the latest changes. Unfortunately, the test can't pass on the mainnet, so I have changed it to testnet to unblock the rollout of the crates (https://github.com/near/near-jsonrpc-client-rs/pull/169/commits/ee966c0f6c9be87a9926ffb381b855a5ae11dd0b). The issue tracked in #170 