### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.16.0...v0.16.1) - 2025-03-27
+
+### Fixed
+
+- Fixed missing serde::Serialize on BroadcastTxAsync and GenesisConfig errors ([#171](https://github.com/near/near-jsonrpc-client-rs/pull/171))
+
 ## [0.16.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.15.1...v0.16.0) - 2025-03-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.16.0 -> 0.16.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.16.0...v0.16.1) - 2025-03-27

### Fixed

- Fixed missing serde::Serialize on BroadcastTxAsync and GenesisConfig errors ([#171](https://github.com/near/near-jsonrpc-client-rs/pull/171))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).