### PR TITLE
Upgrade `near-primitives` dependency to version `0.30.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = ">0.22,<0.30"
-near-primitives = { version = ">0.22,<0.30", features = ["test_utils"] }
-near-chain-configs = ">0.22,<0.30"
-near-jsonrpc-primitives = ">0.22,<0.30"
+near-crypto = "0.30.1"
+near-primitives = { version = "0.30.1", features = ["test_utils"] }
+near-chain-configs = "0.30.1"
+near-jsonrpc-primitives = "0.30.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Title

Upgrade `near-primitives` dependency to version `0.30.1`

## Description

We are currently utilizing this library in our indexer project, where we retrieve data from the RPC client and merge it with additional information from the `near_indexer_primitives` package.

To ensure compatibility and avoid version conflicts across dependencies, we kindly propose upgrading the `near-primitives` dependency to version `0.30.1`. This update will help maintain consistency within our project and facilitate smoother integration.

Thank you for your consideration.
