### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.17.0...v0.18.0) - 2025-08-15
+
+### Other
+
+- [**breaking**] update near-* dependencies to 0.31 release ([#177](https://github.com/near/near-jsonrpc-client-rs/pull/177))
+
 ## [0.17.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.16.1...v0.17.0) - 2025-05-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.17.0 -> 0.18.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.18.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.17.0...v0.18.0) - 2025-08-15

### Other

- [**breaking**] update near-* dependencies to 0.31 release ([#177](https://github.com/near/near-jsonrpc-client-rs/pull/177))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).