### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.0...v0.21.1) - 2026-04-06
+
+### Other
+
+- release v0.21.0 ([#183](https://github.com/near/near-jsonrpc-client-rs/pull/183))
+
 ## [0.21.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.20.0...v0.21.0) - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.0...v0.21.1) - 2026-06-03
+
+### Other
+
+- bump nearcore crates to 0.36 (2.12 / protocol 84) ([#189](https://github.com/near/near-jsonrpc-client-rs/pull/189))
+- release v0.21.0 ([#183](https://github.com/near/near-jsonrpc-client-rs/pull/183))
+
 ## [0.21.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.20.0...v0.21.0) - 2026-04-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.21.0 -> 0.21.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.0...v0.21.1) - 2026-06-03

### Other

- bump nearcore crates to 0.36 (2.12 / protocol 84) ([#189](https://github.com/near/near-jsonrpc-client-rs/pull/189))
- release v0.21.0 ([#183](https://github.com/near/near-jsonrpc-client-rs/pull/183))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).