### PR TITLE
chore: bump nearcore crates to 0.36 (2.12 / protocol 84)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.36.0-rc.1"
-near-primitives = { version = "0.36.0-rc.1", features = ["test_utils"] }
-near-chain-configs = "0.36.0-rc.1"
-near-jsonrpc-primitives = "0.36.0-rc.1"
+near-crypto = "0.36.0-rc.2"
+near-primitives = { version = "0.36.0-rc.2", features = ["test_utils"] }
+near-chain-configs = "0.36.0-rc.2"
+near-jsonrpc-primitives = "0.36.0-rc.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/near/near-jsonrpc-client-rs"
 description = "Lower-level API for interfacing with the NEAR Protocol via JSONRPC"
 categories = ["asynchronous", "api-bindings", "network-programming"]
 keywords = ["near", "api", "jsonrpc", "rpc", "async"]
-rust-version = "1.85.0"
+rust-version = "1.93"
 
 [dependencies]
 log = "0.4.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.35"
-near-primitives = { version = "0.35", features = ["test_utils"] }
-near-chain-configs = "0.35"
-near-jsonrpc-primitives = "0.35"
+near-crypto = "0.36.0-rc.1"
+near-primitives = { version = "0.36.0-rc.1", features = ["test_utils"] }
+near-chain-configs = "0.36.0-rc.1"
+near-jsonrpc-primitives = "0.36.0-rc.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.36.0-rc.2"
-near-primitives = { version = "0.36.0-rc.2", features = ["test_utils"] }
-near-chain-configs = "0.36.0-rc.2"
-near-jsonrpc-primitives = "0.36.0-rc.2"
+near-crypto = "0.36.0"
+near-primitives = { version = "0.36.0", features = ["test_utils"] }
+near-chain-configs = "0.36.0"
+near-jsonrpc-primitives = "0.36.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Bumps `near-crypto`, `near-primitives`, `near-chain-configs`, and `near-jsonrpc-primitives` from `0.35` to `0.36.0` for nearcore 2.12 (protocol 84, now live on mainnet). MSRV moves to `1.93`, required by the 2.12 Wasmtime+Winch engine.

Base of the DevEx 2.12 upgrade — socialdb, near-cli, cargo-near, near-workspaces, and near-sdk follow once this publishes.
