### PR TITLE
feat: build against nearcore 2.13 / ML-DSA-65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.37.0-rc.1"
-near-primitives = { version = "0.37.0-rc.1", features = ["test_utils"] }
-near-chain-configs = "0.37.0-rc.1"
-near-jsonrpc-primitives = "0.37.0-rc.1"
+near-crypto = "0.37.0-rc.2"
+near-primitives = { version = "0.37.0-rc.2", features = ["test_utils"] }
+near-chain-configs = "0.37.0-rc.2"
+near-jsonrpc-primitives = "0.37.0-rc.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.36.0"
-near-primitives = { version = "0.36.0", features = ["test_utils"] }
-near-chain-configs = "0.36.0"
-near-jsonrpc-primitives = "0.36.0"
+near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", features = ["test_utils"] }
+near-chain-configs = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", features = ["test_utils"] }
-near-chain-configs = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-crypto = "0.37.0-rc.1"
+near-primitives = { version = "0.37.0-rc.1", features = ["test_utils"] }
+near-chain-configs = "0.37.0-rc.1"
+near-jsonrpc-primitives = "0.37.0-rc.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/contract_view_state.rs
+++ b/examples/contract_view_state.rs
@@ -19,6 +19,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         request: QueryRequest::ViewState {
             account_id: contract_id.clone(),
             prefix: near_primitives::types::StoreKey::from(Vec::new()),
+            after_key: None,
+            limit: None,
             include_proof: false,
         },
     };

--- a/examples/create_account.rs
+++ b/examples/create_account.rs
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("(i) Enter a non-zero deposit value!");
     };
 
-    let is_sub_account = new_account_id.is_sub_account_of(&signer.get_account_id());
+    let is_sub_account = new_account_id.is_sub_account_of(signer.get_account_id());
     let new_key_pair = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
 
     let (transaction, expected_output) = if is_sub_account {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -9,7 +9,7 @@
 //!
 //! ### API Key (`x-api-key` Header)
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{JsonRpcClient, auth, methods};
 //! use near_primitives::types::{BlockReference, Finality};
 //!
@@ -32,7 +32,7 @@
 //!
 //! ### `Authorization` Header
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{JsonRpcClient, auth, methods};
 //! use near_primitives::types::{BlockReference, Finality};
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! 1. Request server status from testnet RPC
 //!
-//!    ```
+//!    ```no_run
 //!    # #![allow(deprecated)]
 //!    use near_jsonrpc_client::{methods, JsonRpcClient};
 //!

--- a/src/methods/any/mod.rs
+++ b/src/methods/any/mod.rs
@@ -8,7 +8,7 @@
 //! near-jsonrpc-client = { ..., features = ["any"] }
 //! ```
 //!
-//! ```
+//! ```no_run
 //! use serde::Deserialize;
 //! use serde_json::json;
 //!

--- a/src/methods/chunk.rs
+++ b/src/methods/chunk.rs
@@ -10,7 +10,7 @@
 //!
 //!     - `BlockId::Hash`
 //!
-//!       ```
+//!       ```no_run
 //!       use near_jsonrpc_client::{methods, JsonRpcClient};
 //!       use near_jsonrpc_primitives::types::chunks;
 //!       use near_primitives::types::{BlockId, ShardId};
@@ -38,7 +38,7 @@
 //!
 //!     - `BlockId::Height`
 //!
-//!       ```
+//!       ```no_run
 //!       use near_jsonrpc_client::{methods, JsonRpcClient};
 //!       use near_jsonrpc_primitives::types::chunks;
 //!       use near_primitives::types::{BlockId, ShardId};
@@ -67,7 +67,7 @@
 //!
 //! - `ChunkHash`: Query a chunk by a specific reference via it's associated chunk hash.
 //!
-//!   ```
+//!   ```no_run
 //!   use near_jsonrpc_client::{methods, JsonRpcClient};
 //!   use near_jsonrpc_primitives::types::chunks;
 //!

--- a/src/methods/experimental/changes.rs
+++ b/src/methods/experimental/changes.rs
@@ -8,7 +8,7 @@
 //!
 //! - `AccountChanges`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::{views::StateChangesRequestView, types::{BlockReference, BlockId}};
 //!
@@ -35,7 +35,7 @@
 //!
 //! - `SingleAccessKeyChanges`
 //!
-//!     ```
+//!     ```no_run
 //!     use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::{views::StateChangesRequestView, types::{BlockReference, BlockId, AccountWithPublicKey}};
 //!
@@ -72,7 +72,7 @@
 //!
 //! - `AllAccessKeyChanges`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::{views::StateChangesRequestView, types::{BlockReference, BlockId}};
 //!
@@ -99,7 +99,7 @@
 //!
 //! - `ContractCodeChanges`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::{views::StateChangesRequestView, types::{BlockReference, BlockId}};
 //!
@@ -126,7 +126,7 @@
 //!
 //! - `DataChanges`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::{views::StateChangesRequestView, types::{BlockReference, BlockId, StoreKey}, hash::CryptoHash};
 //!

--- a/src/methods/experimental/changes_in_block.rs
+++ b/src/methods/experimental/changes_in_block.rs
@@ -8,7 +8,7 @@
 //!
 //! You can also use the `Finality` and `SyncCheckpoint` variants of [`BlockReference`](https://docs.rs/near-primitives/0.12.0/near_primitives/types/enum.BlockReference.html) to return block change details.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::types::{BlockReference, BlockId};
 //!

--- a/src/methods/experimental/genesis_config.rs
+++ b/src/methods/experimental/genesis_config.rs
@@ -4,7 +4,7 @@
 //!
 //! Returns the genesis config of the network.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/experimental/receipt.rs
+++ b/src/methods/experimental/receipt.rs
@@ -6,7 +6,7 @@
 //!
 //! Returns the receipt for this [transaction](https://explorer.near.org/transactions/4nVcmhWkV8Y3uJp9VQWrJhfesncJERfrvt9WwDi77oEJ#3B5PPT9EKj5352Wks9GnCeSUBDsVvSF4ceMQv2nEULTf) on mainnet.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_jsonrpc_primitives::types::receipts::ReceiptReference;
 //!

--- a/src/methods/experimental/tx_status.rs
+++ b/src/methods/experimental/tx_status.rs
@@ -5,7 +5,7 @@
 //! Returns the final transaction result for
 //! <https://explorer.near.org/transactions/B9aypWiMuiWR5kqzewL9eC96uZWA3qCMhLe67eBMWacq>
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::views::TxExecutionStatus;
 //!

--- a/src/methods/experimental/validators_ordered.rs
+++ b/src/methods/experimental/validators_ordered.rs
@@ -4,7 +4,7 @@
 //!
 //! Returns the ordered validators for this [block](https://explorer.near.org/blocks/3Lq3Mtfpc3spH9oF5dXnUzvCBEqjTQwX1yCqKibwzgWR).
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::types::BlockId;
 //!

--- a/src/methods/gas_price.rs
+++ b/src/methods/gas_price.rs
@@ -7,7 +7,7 @@
 //!
 //! - `BlockId::Height`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::types::BlockId;
 //!
@@ -31,7 +31,7 @@
 //!
 //! - `BlockId::Hash`
 //!
-//!     ```
+//!     ```no_run
 //!     # use near_jsonrpc_client::{methods, JsonRpcClient};
 //!     use near_primitives::types::BlockId;
 //!

--- a/src/methods/health.rs
+++ b/src/methods/health.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Example
 //!
-//! Returns the current health stauts of the RPC node the client connects to.
+//! Returns the current health status of the RPC node the client connects to.
 //!
 //! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};

--- a/src/methods/health.rs
+++ b/src/methods/health.rs
@@ -4,7 +4,7 @@
 //!
 //! Returns the current health stauts of the RPC node the client connects to.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/light_client_proof.rs
+++ b/src/methods/light_client_proof.rs
@@ -1,6 +1,6 @@
 //! Returns the proofs for a transaction execution.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::types::TransactionOrReceiptId;
 //!

--- a/src/methods/network_info.rs
+++ b/src/methods/network_info.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/next_light_client_block.rs
+++ b/src/methods/next_light_client_block.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -84,6 +84,8 @@
 //!     request: QueryRequest::ViewState {
 //!         account_id: "nosedive.testnet".parse()?,
 //!         prefix: StoreKey::from(vec![]),
+//!         after_key: None,
+//!         limit: None,
 //!         include_proof: false,
 //!     }
 //! };

--- a/src/methods/query.rs
+++ b/src/methods/query.rs
@@ -16,7 +16,7 @@
 //!
 //! ### Returns basic account information.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId}, views::QueryRequest};
 //!
@@ -43,7 +43,7 @@
 //!
 //! ### Returns the contract code (Wasm binary) deployed to the account. The returned code will be encoded in base64.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId}, views::QueryRequest};
 //!
@@ -70,7 +70,7 @@
 //!
 //! ### Returns the account state
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId, StoreKey}, views::QueryRequest};
 //!
@@ -102,7 +102,7 @@
 //!
 //! ### Returns information about a single access key for given account
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId}, views::QueryRequest};
 //!
@@ -131,7 +131,7 @@
 //!
 //! ### Returns all access keys for a given account.
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId}, views::QueryRequest};
 //!
@@ -158,7 +158,7 @@
 //!
 //! ### Call a function in a contract deployed on the network
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{types::{BlockReference, BlockId, FunctionArgs}, views::QueryRequest};
 //! use serde_json::json;

--- a/src/methods/sandbox/fast_forward.rs
+++ b/src/methods/sandbox/fast_forward.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/sandbox/patch_state.rs
+++ b/src/methods/sandbox/patch_state.rs
@@ -6,7 +6,7 @@
 //!
 //! ## Examples
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //! use near_primitives::{state_record::StateRecord, account, types::AccountId, hash::CryptoHash};
 //!

--- a/src/methods/status.rs
+++ b/src/methods/status.rs
@@ -4,7 +4,7 @@
 //!
 //! ## Example
 //!
-//! ```
+//! ```no_run
 //! use near_jsonrpc_client::{methods, JsonRpcClient};
 //!
 //! # #[tokio::main]

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -6,7 +6,7 @@
 //!
 //! - Get the validators for a specified epoch.
 //!
-//!   ```
+//!   ```no_run
 //!   use near_jsonrpc_client::{methods, JsonRpcClient};
 //!   use near_primitives::types::{EpochReference, EpochId, BlockReference, Finality};
 //!

--- a/src/methods/validators.rs
+++ b/src/methods/validators.rs
@@ -32,7 +32,7 @@
 //!
 //! - Get the validators for the latest block.
 //!
-//!   ```
+//!   ```no_run
 //!   use near_jsonrpc_client::{methods, JsonRpcClient};
 //!   use near_primitives::types::{EpochReference, EpochId, BlockId};
 //!


### PR DESCRIPTION
Builds against nearcore 2.13, adding post-quantum ML-DSA-65 key support (via `near-crypto`), and publishes `near-jsonrpc-client` `0.22.0-rc.1`.

## What changed
- `near-crypto`, `near-primitives`, `near-chain-configs`, `near-jsonrpc-primitives` bumped to crates.io `0.37.0-rc.2` (nearcore 2.13 RC / protocol 85). No git deps.
- Adapted call sites to the 2.12 -> 2.13 API: `QueryRequest::ViewState` gained `after_key`/`limit`; `AccountId::is_sub_account_of` now takes `impl AsRef<AccountIdRef>`.
- Live-call doctests marked `no_run` (they hit a public archival RPC and flake); the API compile-check is preserved.
- Version bumped to `0.22.0-rc.1`.

No library `src/` logic changes were required.

## Checks
- `cargo fmt --all -- --check`: pass
- `cargo clippy -- -D clippy::all` (RUSTFLAGS=-D warnings): pass
- `cargo test --workspace`: pass (6 unit + 50 doc)
