### PR TITLE
chore: release v0.22.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.21.2) - 2026-07-01
+
+### Added
+
+- build against nearcore 2.13 / ML-DSA-65 ([#190](https://github.com/near/near-jsonrpc-client-rs/pull/190))
+
 ## [0.21.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.0...v0.21.1) - 2026-06-03
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.21.2](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.21.2) - 2026-07-01
+## [0.22.0-rc.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.22.0-rc.1) - 2026-07-01
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.21.2"
+version = "0.22.0-rc.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.21.1 -> 0.21.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.2](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.21.2) - 2026-07-01

### Added

- build against nearcore 2.13 / ML-DSA-65 ([#190](https://github.com/near/near-jsonrpc-client-rs/pull/190))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).