### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.22.0) - 2026-07-09
+
+### Added
+
+- build against nearcore 2.13 / ML-DSA-65 ([#190](https://github.com/near/near-jsonrpc-client-rs/pull/190))
+
+### Other
+
+- pin to nearcore 2.13.0 stable ([#192](https://github.com/near/near-jsonrpc-client-rs/pull/192))
+
 ## [0.22.0-rc.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.22.0-rc.1) - 2026-07-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -19,10 +19,10 @@ thiserror = "2.0"
 serde_json = "1.0.85"
 lazy_static = "1.4.0"
 
-near-crypto = "0.37.0-rc.2"
-near-primitives = { version = "0.37.0-rc.2", features = ["test_utils"] }
-near-chain-configs = "0.37.0-rc.2"
-near-jsonrpc-primitives = "0.37.0-rc.2"
+near-crypto = "0.37.0"
+near-primitives = { version = "0.37.0", features = ["test_utils"] }
+near-chain-configs = "0.37.0"
+near-jsonrpc-primitives = "0.37.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
nearcore 2.13.0 is now on crates.io (near-primitives/near-crypto/near-chain-configs/near-jsonrpc-primitives at 0.37.0). This swaps the `0.37.0-rc.2` pins to `0.37.0` and releases near-jsonrpc-client 0.22.0 (from 0.22.0-rc.1).

This is the publish gate for the downstream DevEx crates that depend on a stable jsonrpc-client.