### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.22.0...v0.22.1) - 2026-08-10
+
+### Other
+
+- maintenance and update tokens to fix ci ([#193](https://github.com/near/near-jsonrpc-client-rs/pull/193))
+
 ## [0.22.0](https://github.com/near/near-jsonrpc-client-rs/compare/v0.21.1...v0.22.0) - 2026-07-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-jsonrpc-client"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-jsonrpc-client`: 0.22.0 -> 0.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.1](https://github.com/near/near-jsonrpc-client-rs/compare/v0.22.0...v0.22.1) - 2026-08-10

### Other

- maintenance and update tokens to fix ci ([#193](https://github.com/near/near-jsonrpc-client-rs/pull/193))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).